### PR TITLE
Type code generalisation

### DIFF
--- a/anyblok_wms_base/core/goods/type.py
+++ b/anyblok_wms_base/core/goods/type.py
@@ -31,7 +31,8 @@ class Type:
     id = Integer(label="Identifier", primary_key=True)
     """Primary key"""
 
-    code = String(label=u"Identifying code", index=True)
+    code = String(label=u"Identifying code", index=True,
+                  unique=True, nullable=False)
     """Uniquely identifying code.
 
     As a convenience, and for sharing with other applications.

--- a/anyblok_wms_base/core/operation/assembly.py
+++ b/anyblok_wms_base/core/operation/assembly.py
@@ -437,7 +437,7 @@ class Assembly(Operation):
             goods = avatar.goods
             props = goods.properties
             unpack_outcome = dict(
-                type=goods.type.id,
+                type=goods.type.code,
                 quantity=1,  # TODO hook for wms_quantity
                 )
             if props is not None:

--- a/anyblok_wms_base/core/operation/tests/test_arrival.py
+++ b/anyblok_wms_base/core/operation/tests/test_arrival.py
@@ -14,7 +14,8 @@ class TestArrival(WmsTestCase):
     def setUp(self):
         super(TestArrival, self).setUp()
         Wms = self.registry.Wms
-        self.goods_type = Wms.Goods.Type.insert(label="My good type")
+        self.goods_type = Wms.Goods.Type.insert(label="My good type",
+                                                code='MGT')
         self.incoming_loc = Wms.Location.insert(label="Incoming location")
         self.stock = Wms.Location.insert(label="Stock")
         self.Arrival = Wms.Operation.Arrival
@@ -112,7 +113,8 @@ class TestOperationBase(WmsTestCase):
     def setUp(self):
         super(TestOperationBase, self).setUp()
         Wms = self.registry.Wms
-        self.goods_type = Wms.Goods.Type.insert(label="My good type")
+        self.goods_type = Wms.Goods.Type.insert(label="My good type",
+                                                code='MGT')
         self.incoming_loc = Wms.Location.insert(label="Incoming location")
         self.stock = Wms.Location.insert(label="Stock")
         self.Arrival = Wms.Operation.Arrival

--- a/anyblok_wms_base/core/operation/tests/test_assembly.py
+++ b/anyblok_wms_base/core/operation/tests/test_assembly.py
@@ -598,9 +598,6 @@ class TestAssembly(WmsTestCase):
         self.create_outcome_type(dict(default={
             'inputs': [{'type': 'GT1', 'quantity': 2}],
         }))
-        self.create_outcome_type(dict(default={
-            'inputs': [{'type': 'GT1', 'quantity': 2}],
-        }))
 
         avatars = self.create_goods(((gt1, 2), (gt2, 1)))
 
@@ -617,14 +614,11 @@ class TestAssembly(WmsTestCase):
     def test_create_done_extra_allowed(self):
         gt1 = self.Goods.Type.insert(code='GT1')
         gt2 = self.Goods.Type.insert(code='GT2')
+
         self.create_outcome_type(dict(default={
             'inputs': [{'type': 'GT1', 'quantity': 2}],
             'allow_extra_inputs': True,
         }))
-        self.create_outcome_type(
-            dict(default=dict(
-                inputs=[dict(type='GT1', quantity=2)],
-                allow_extra_inputs=True)))
         avatars = self.create_goods(((gt1, 2), (gt2, 1)))
 
         assembly = self.Assembly.create(inputs=avatars,

--- a/anyblok_wms_base/core/operation/tests/test_assembly.py
+++ b/anyblok_wms_base/core/operation/tests/test_assembly.py
@@ -82,11 +82,11 @@ class TestAssembly(WmsTestCase):
         self.assertEqual(outcome.goods.get_property('unpack_outcomes'),
                          [dict(properties=dict(batch=None,
                                                expiration_date='2010-01-01'),
-                               type=gt1.id,
+                               type='GT1',
                                quantity=1),
-                          dict(type=gt1.id,
+                          dict(type='GT1',
                                quantity=1),
-                          dict(type=gt2.id,
+                          dict(type='GT2',
                                quantity=1),
                           ])
 
@@ -128,9 +128,9 @@ class TestAssembly(WmsTestCase):
         self.assertEqual(outcome.goods.get_property('unpack_outcomes'),
                          [dict(forward_properties=['bar'],
                                properties=dict(batch=None, main=True),
-                               type=gt1.id,
+                               type='GT1',
                                quantity=1),
-                          dict(type=gt2.id,
+                          dict(type='GT2',
                                quantity=1),
                           ])
         self.assertEqual(outcome.goods.get_property('colour'), 'blue')
@@ -246,9 +246,9 @@ class TestAssembly(WmsTestCase):
         }))
         avatars = self.create_goods([(gt1, 1)])
 
-        gt2 = self.Goods.Type.insert(code='GT2')
+        self.Goods.Type.insert(code='GT2')
         avatars[0].goods.set_property('unpack_outcomes',
-                                      dict(type=gt2.id, quantity=4))
+                                      dict(type='GT2', quantity=4))
 
         assembly = self.Assembly.create(inputs=avatars,
                                         outcome_type=self.outcome_type,
@@ -257,7 +257,7 @@ class TestAssembly(WmsTestCase):
 
         outcome = self.assert_singleton(assembly.outcomes)
         self.assertEqual(outcome.goods.get_property('unpack_outcomes'),
-                         dict(type=gt2.id, quantity=4))
+                         dict(type='GT2', quantity=4))
 
     def test_create_done_forward_props_per_inputs_spec_revert(self):
         gt1 = self.Goods.Type.insert(code='GT1')
@@ -298,15 +298,15 @@ class TestAssembly(WmsTestCase):
                  # hence it always is at least None.
                  batch=None,
                  unpack_outcomes=[dict(properties=dict(batch=None, qa='ok'),
-                                       type=gt1.id,
+                                       type='GT1',
                                        forward_properties=['foo'],
                                        quantity=1),
                                   dict(properties=dict(batch=None, qa='ok'),
-                                       type=gt1.id,
+                                       type='GT1',
                                        forward_properties=['foo'],
                                        quantity=1),
                                   dict(properties=dict(batch=None),
-                                       type=gt2.id,
+                                       type='GT2',
                                        forward_properties=['bar', 'foo'],
                                        quantity=1),
                                   ]))
@@ -429,15 +429,15 @@ class TestAssembly(WmsTestCase):
                  done=True,
                  bar=3,
                  unpack_outcomes=[dict(properties=dict(batch=None, qa='ok'),
-                                       type=gt1.id,
+                                       type='GT1',
                                        forward_properties=['foo'],
                                        quantity=1),
                                   dict(properties=dict(batch=None, qa='ok'),
-                                       type=gt2.id,
+                                       type='GT2',
                                        forward_properties=['foo'],
                                        quantity=1),
                                   dict(properties=dict(batch=None, qa='ok'),
-                                       type=gt2.id,
+                                       type='GT2',
                                        quantity=1),
                                   ]))
 
@@ -502,19 +502,19 @@ class TestAssembly(WmsTestCase):
                  unpack_outcomes=[dict(properties=dict(batch=None,
                                                        qa='ok',
                                                        expiry=2015),
-                                       type=gt1.id,
+                                       type='GT1',
                                        forward_properties=['foo'],
                                        quantity=1),
                                   dict(properties=dict(batch=None,
                                                        qa='ok',
                                                        expiry=2016),
-                                       type=gt2.id,
+                                       type='GT2',
                                        forward_properties=['foo'],
                                        quantity=1),
                                   dict(properties=dict(batch=None,
                                                        qa='ok',
                                                        expiry=2017),
-                                       type=gt2.id,
+                                       type='GT2',
                                        quantity=1),
                                   ]))
 
@@ -636,7 +636,7 @@ class TestAssembly(WmsTestCase):
         self.assertEqual(outcome.goods.type, self.outcome_type)
         self.assertEqual(outcome.state, 'present')
         self.assertEqual(outcome.goods.get_property('unpack_outcomes'),
-                         [dict(type=gt2.id,
+                         [dict(type='GT2',
                                quantity=1,
                                local_goods_ids=[avatars[-1].goods.id])])
 

--- a/anyblok_wms_base/core/operation/tests/test_operation.py
+++ b/anyblok_wms_base/core/operation/tests/test_operation.py
@@ -25,7 +25,8 @@ class TestOperation(WmsTestCase):
         self.Goods = Wms.Goods
         self.incoming_loc = Wms.Location.insert(label="Incoming location")
         self.stock = Wms.Location.insert(label="Stock")
-        self.goods_type = self.Goods.Type.insert(label="My good type")
+        self.goods_type = self.Goods.Type.insert(label="My good type",
+                                                 code='MyGT')
 
     def test_history(self):
         arrival = self.Operation.Arrival.create(goods_type=self.goods_type,

--- a/anyblok_wms_base/core/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/core/operation/tests/test_unpack.py
@@ -52,11 +52,11 @@ class TestUnpack(WmsTestCase):
             self.Avatar.query().filter(self.Avatar.goods == goods))
 
     def test_done_one_unpacked_type_props(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=3,
                          forward_properties=['foo', 'bar'],
                          required_properties=['foo'],
@@ -76,18 +76,20 @@ class TestUnpack(WmsTestCase):
 
     def test_done_clone_one_not_clone(self):
         unpacked_clone_type = self.Goods.Type.insert(
+            code='clone',
             label="Unpacked, clone props")
         unpacked_fwd_type = self.Goods.Type.insert(
+            code='fwd',
             label="Unpacked, fwd one prop")
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 outcomes=[
-                    dict(type=unpacked_fwd_type.id,
+                    dict(type=unpacked_fwd_type.code,
                          quantity=3,
                          forward_properties=['foo', 'bar'],
                          required_properties=['foo'],
                          ),
-                    dict(type=unpacked_clone_type.id,
+                    dict(type=unpacked_clone_type.code,
                          quantity=2,
                          forward_properties='clone'
                          )
@@ -112,12 +114,12 @@ class TestUnpack(WmsTestCase):
             self.assertEqual(goods.get_property('foo'), 3)
 
     def test_done_one_unpacked_type_uniform(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 uniform_outcomes=True,
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=3,
                          )
                 ],
@@ -140,7 +142,7 @@ class TestUnpack(WmsTestCase):
         Properties after unpack are forwarded according to configuration
         on the packs' Goods Type and on the packs' properties.
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 forward_properties=['foo', 'bar'],
@@ -149,7 +151,7 @@ class TestUnpack(WmsTestCase):
             properties=dict(foo=3,
                             baz='second hand',
                             unpack_outcomes=[
-                                dict(type=unpacked_type.id,
+                                dict(type=unpacked_type.code,
                                      quantity=2,
                                      properties=dict(direct='hop',
                                                      foo='will be overridden',
@@ -179,7 +181,7 @@ class TestUnpack(WmsTestCase):
         Properties after unpack are still forwarded according to configuration
         on the packs' Goods Type and on the packs' properties.
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         outcome1 = self.Goods.insert(type=unpacked_type)
         outcome1.set_property('grade', 'best')
         outcome2 = self.Goods.insert(type=unpacked_type)
@@ -193,13 +195,13 @@ class TestUnpack(WmsTestCase):
             properties=dict(foo=3,
                             bar='yes',
                             unpack_outcomes=[
-                                dict(type=unpacked_type.id,
+                                dict(type=unpacked_type.code,
                                      quantity=1,
                                      local_goods_ids=[outcome1.id],
                                      properties=dict(direct='ignored'),
                                      forward_properties=['bar']
                                      ),
-                                dict(type=unpacked_type.id,
+                                dict(type=unpacked_type.code,
                                      quantity=1,
                                      local_goods_ids=[outcome2.id],
                                      properties=dict(direct='ignored'),
@@ -225,7 +227,7 @@ class TestUnpack(WmsTestCase):
     def test_done_non_uniform_local_id_wrong_qty(self):
         """Unpack with local_goods_ids in pack properties, wrong quantity
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         outcome1 = self.Goods.insert(type=unpacked_type)
 
         self.create_packs(
@@ -236,7 +238,7 @@ class TestUnpack(WmsTestCase):
             properties=dict(foo=3,
                             bar='yes',
                             unpack_outcomes=[
-                                dict(type=unpacked_type.id,
+                                dict(type=unpacked_type.code,
                                      quantity=2,
                                      local_goods_ids=[outcome1.id],
                                      ),
@@ -251,18 +253,18 @@ class TestUnpack(WmsTestCase):
         exckw = arc.exception.kwargs
         self.assertEqual(exckw.get('target_qty'), 2)
         self.assertEqual(exckw.get('spec'),
-                         dict(type=unpacked_type.id,
+                         dict(type=unpacked_type.code,
                               quantity=2,
                               local_goods_ids=[outcome1.id],
                               forward_properties=['foo'],
                               required_properties=['foo']))
 
     def test_done_one_unpacked_type_missing_props(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=3,
                          forward_properties=['foo', 'bar'],
                          required_properties=['foo'],
@@ -304,10 +306,10 @@ class TestUnpack(WmsTestCase):
 
     def test_done_one_unpacked_type_no_props(self):
         """Unpacking operation, forwarding no properties."""
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(type_behaviours=dict(unpack=dict(
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=3,
                          )
                 ]
@@ -329,7 +331,7 @@ class TestUnpack(WmsTestCase):
     def test_plan_execute(self):
         """Plan an Unpack (non uniform scenario), then execute it
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 forward_properties=['foo', 'bar'],
@@ -338,7 +340,7 @@ class TestUnpack(WmsTestCase):
             properties=dict(foo=3,
                             baz='second hand',
                             unpack_outcomes=[
-                                dict(type=unpacked_type.id,
+                                dict(type=unpacked_type.code,
                                      quantity=2,
                                      forward_properties=['bar', 'baz']
                                      )
@@ -421,12 +423,12 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(list(exc_kwargs.get('inputs')), [self.packs])
 
     def test_repr(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 uniform_outcomes=True,
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=6,
                          ),
                 ]),
@@ -438,12 +440,12 @@ class TestUnpack(WmsTestCase):
         str(unp)
 
     def test_assembly_name_no_behaviour(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 uniform_outcomes=True,
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=1,
                          ),
                 ]),
@@ -456,17 +458,17 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(unp.reverse_assembly_name(), 'pack')
 
     def test_revert_default_assembly_final(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked", code="GT")
+        unpacked_type = self.Goods.Type.insert(code="GT")
         self.create_packs(
             type_behaviours=dict(
                 unpack=dict(
                     uniform_outcomes=True,
-                    outcomes=[dict(type=unpacked_type.id,
+                    outcomes=[dict(type='GT',
                                    quantity=2),
                               ]),
                 assembly=dict(
                     pack=dict(
-                        inputs=[dict(type=unpacked_type.code,
+                        inputs=[dict(type='GT',
                                      quantity=2)]
                     ),
                 )
@@ -486,12 +488,12 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(quantity(goods_type=self.packed_goods_type), 1)
 
     def test_revert_default_assembly_not_final(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked", code="GT")
+        unpacked_type = self.Goods.Type.insert(code="GT")
         self.create_packs(
             type_behaviours=dict(
                 unpack=dict(
                     uniform_outcomes=True,
-                    outcomes=[dict(type=unpacked_type.id,
+                    outcomes=[dict(type=unpacked_type.code,
                                    quantity=2),
                               ]),
                 assembly=dict(
@@ -534,7 +536,7 @@ class TestUnpack(WmsTestCase):
                 unpack=dict(
                     uniform_outcomes=True,
                     reverse_assembly='bolt',
-                    outcomes=[dict(type=unpacked_type.id,
+                    outcomes=[dict(type=unpacked_type.code,
                                    quantity=2),
                               ]),
                 assembly=dict(
@@ -562,12 +564,12 @@ class TestUnpack(WmsTestCase):
     def test_cancel(self):
         """Plan an Unpack (uniform scenario), then cancel it
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 uniform_outcomes=True,
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=6,
                          ),
                 ],

--- a/anyblok_wms_base/core/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/core/operation/tests/test_unpack.py
@@ -27,6 +27,7 @@ class TestUnpack(WmsTestCase):
     def create_packs(self, type_behaviours=None, properties=None):
         self.packed_goods_type = self.Goods.Type.insert(
             label="Pack",
+            code='PACK',
             behaviours=type_behaviours)
         self.arrival = self.Operation.Arrival.create(
             goods_type=self.packed_goods_type,

--- a/anyblok_wms_base/core/operation/unpack.py
+++ b/anyblok_wms_base/core/operation/unpack.py
@@ -112,9 +112,9 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
         packs = self.input
         dt_execution = self.dt_execution
         spec = self.get_outcome_specs()
-        type_ids = set(outcome['type'] for outcome in spec)
-        outcome_types = {gt.id: gt for gt in GoodsType.query().filter(
-            GoodsType.id.in_(type_ids)).all()}
+        type_codes = set(outcome['type'] for outcome in spec)
+        outcome_types = {gt.code: gt for gt in GoodsType.query().filter(
+            GoodsType.code.in_(type_codes)).all()}
 
         outcome_state = 'present' if self.state == 'done' else 'future'
         if self.state == 'done':

--- a/anyblok_wms_base/core/tests/__init__.py
+++ b/anyblok_wms_base/core/tests/__init__.py
@@ -15,7 +15,8 @@ class TestCore(BlokTestCase):
 
     def test_minimal(self):
         Wms = self.registry.Wms
-        goods_type = Wms.Goods.Type.insert(label="My good type")
+        goods_type = Wms.Goods.Type.insert(label="My good type",
+                                           code='MyGT')
         self.assertEqual(goods_type.label, "My good type")
 
         loc = Wms.Location.insert(label="Root location")

--- a/anyblok_wms_base/core/tests/test_goods_quantity.py
+++ b/anyblok_wms_base/core/tests/test_goods_quantity.py
@@ -24,7 +24,8 @@ class TestQuantity(WmsTestCase):
 
         self.Goods = Wms.Goods
         self.Avatar = Wms.Goods.Avatar
-        self.goods_type = self.Goods.Type.insert(label="My goods")
+        self.goods_type = self.Goods.Type.insert(label="My goods",
+                                                 code='MyGT')
 
         self.Location = Wms.Location
         self.stock = Wms.Location.insert(label="Stock", code='STK')

--- a/anyblok_wms_base/core/tests/test_location.py
+++ b/anyblok_wms_base/core/tests/test_location.py
@@ -21,7 +21,8 @@ class TestLocation(WmsTestCase):
 
         self.Goods = Wms.Goods
         self.Avatar = Wms.Goods.Avatar
-        self.goods_type = self.Goods.Type.insert(label="My goods")
+        self.goods_type = self.Goods.Type.insert(label="My goods",
+                                                 code='MyGT')
 
         self.Location = Wms.Location
         self.stock = Wms.Location.insert(label="Stock", code='STK')

--- a/anyblok_wms_base/quantity/operation/tests/test_aggregate.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_aggregate.py
@@ -24,7 +24,8 @@ class TestAggregate(WmsTestCase):
         super(TestAggregate, self).setUp()
         Wms = self.registry.Wms
         Operation = Wms.Operation
-        self.goods_type = Wms.Goods.Type.insert(label="My good type")
+        self.goods_type = Wms.Goods.Type.insert(label="My good type",
+                                                code="MyGT")
         self.loc = Wms.Location.insert(label="Incoming location")
 
         # The arrival fields doesn't matter, we'll insert goods directly

--- a/anyblok_wms_base/quantity/operation/tests/test_arrival.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_arrival.py
@@ -14,7 +14,8 @@ class TestArrival(WmsTestCase):
     def setUp(self):
         super(TestArrival, self).setUp()
         Wms = self.registry.Wms
-        self.goods_type = Wms.Goods.Type.insert(label="My good type")
+        self.goods_type = Wms.Goods.Type.insert(label="My good type",
+                                                code='MyGT')
         self.incoming_loc = Wms.Location.insert(label="Incoming location")
         self.stock = Wms.Location.insert(label="Stock")
         self.Arrival = Wms.Operation.Arrival
@@ -119,7 +120,8 @@ class TestOperationBase(WmsTestCase):
     def setUp(self):
         super(TestOperationBase, self).setUp()
         Wms = self.registry.Wms
-        self.goods_type = Wms.Goods.Type.insert(label="My good type")
+        self.goods_type = Wms.Goods.Type.insert(label="My good type",
+                                                code='MyGT')
         self.incoming_loc = Wms.Location.insert(label="Incoming location")
         self.stock = Wms.Location.insert(label="Stock")
         self.Arrival = Wms.Operation.Arrival

--- a/anyblok_wms_base/quantity/operation/tests/test_split.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_split.py
@@ -33,7 +33,8 @@ class TestSplit(WmsTestCase):
         Wms = self.registry.Wms
         self.Operation = Operation = Wms.Operation
         self.Goods = Wms.Goods
-        self.goods_type = Wms.Goods.Type.insert(label="My good type")
+        self.goods_type = Wms.Goods.Type.insert(label="My good type",
+                                                code='MyGT')
         self.incoming_loc = Wms.Location.insert(label="Incoming location")
         self.stock = Wms.Location.insert(label="Stock")
 

--- a/anyblok_wms_base/quantity/operation/tests/test_splitter.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_splitter.py
@@ -23,7 +23,8 @@ class TestSplitterOperation(WmsTestCase):
         super(TestSplitterOperation, self).setUp()
         Wms = self.registry.Wms
         Operation = Wms.Operation
-        self.goods_type = Wms.Goods.Type.insert(label="My good type")
+        self.goods_type = Wms.Goods.Type.insert(label="My good type",
+                                                code='MyGT')
         self.incoming_loc = Wms.Location.insert(label="Incoming location")
         self.stock = Wms.Location.insert(label="Stock")
 

--- a/anyblok_wms_base/quantity/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_unpack.py
@@ -39,11 +39,11 @@ class TestUnpack(WmsTestCase):
         self.packs = self.assert_singleton(self.arrival.outcomes)
 
     def test_whole_done_one_unpacked_type_props(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=3,
                          forward_properties=['foo', 'bar'],
                          required_properties=['foo'],
@@ -67,18 +67,20 @@ class TestUnpack(WmsTestCase):
 
     def test_whole_done_one_clone_one_not_clone(self):
         unpacked_clone_type = self.Goods.Type.insert(
+            code='clone',
             label="Unpacked, clone props")
         unpacked_fwd_type = self.Goods.Type.insert(
+            code='fwd',
             label="Unpacked, fwd one prop")
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 outcomes=[
-                    dict(type=unpacked_fwd_type.id,
+                    dict(type='fwd',
                          quantity=3,
                          forward_properties=['foo', 'bar'],
                          required_properties=['foo'],
                          ),
-                    dict(type=unpacked_clone_type.id,
+                    dict(type='clone',
                          quantity=2,
                          forward_properties='clone'
                          )
@@ -108,12 +110,12 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(unpacked_goods_fwd_props.get_property('foo'), 3)
 
     def test_whole_done_one_unpacked_unform(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 uniform_outcomes=True,
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=3,
                          )
                 ],
@@ -141,7 +143,7 @@ class TestUnpack(WmsTestCase):
         Properties after unpack are forwarded according to configuration
         on the packs' Goods Type and on the packs' properties.
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 forward_properties=['foo', 'bar'],
@@ -150,7 +152,7 @@ class TestUnpack(WmsTestCase):
             properties=dict(foo=3,
                             baz='second hand',
                             unpack_outcomes=[
-                                dict(type=unpacked_type.id,
+                                dict(type=unpacked_type.code,
                                      quantity=2,
                                      forward_properties=['bar', 'baz']
                                      )
@@ -178,7 +180,7 @@ class TestUnpack(WmsTestCase):
         Properties after unpack are forwarded according to configuration
         on the packs' Goods Type and on the packs' properties.
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         existing = self.Goods.insert(type=unpacked_type, quantity=2)
         existing.set_property('grade', 'best')
         self.create_packs(
@@ -190,7 +192,7 @@ class TestUnpack(WmsTestCase):
             properties=dict(foo=3,
                             baz='yes',
                             unpack_outcomes=[
-                                dict(type=unpacked_type.id,
+                                dict(type=unpacked_type.code,
                                      quantity=2,
                                      local_goods_ids=[existing.id],
                                      forward_properties=['bar', 'baz']
@@ -219,7 +221,7 @@ class TestUnpack(WmsTestCase):
         Properties after unpack are forwarded according to configuration
         on the packs' Goods Type and on the packs' properties.
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         existing = self.Goods.insert(type=unpacked_type, quantity=2)
         existing.set_property('grade', 'best')
         self.create_packs(
@@ -231,7 +233,7 @@ class TestUnpack(WmsTestCase):
             properties=dict(foo=3,
                             baz='yes',
                             unpack_outcomes=[
-                                dict(type=unpacked_type.id,
+                                dict(type=unpacked_type.code,
                                      quantity=2,
                                      local_goods_ids=[existing.id],
                                      forward_properties=['bar', 'baz']
@@ -246,18 +248,18 @@ class TestUnpack(WmsTestCase):
         exckw = arc.exception.kwargs
         self.assertEqual(exckw.get('target_qty'), 4)
         self.assertEqual(exckw.get('spec'),
-                         dict(type=unpacked_type.id,
+                         dict(type=unpacked_type.code,
                               quantity=2,
                               local_goods_ids=[existing.id],
                               forward_properties=['bar', 'baz', 'foo'],
                               required_properties=['foo']))
 
     def test_whole_done_one_unpacked_type_missing_props(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=3,
                          forward_properties=['foo', 'bar'],
                          required_properties=['foo'],
@@ -300,10 +302,10 @@ class TestUnpack(WmsTestCase):
 
     def test_whole_done_one_unpacked_type_no_props(self):
         """Unpacking operation, forwarding no properties."""
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(type_behaviours=dict(unpack=dict(
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=3,
                          )
                 ]
@@ -327,7 +329,7 @@ class TestUnpack(WmsTestCase):
     def test_whole_plan_execute(self):
         """Plan an Unpack (non uniform scenario), then execute it
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 forward_properties=['foo', 'bar'],
@@ -336,7 +338,7 @@ class TestUnpack(WmsTestCase):
             properties=dict(foo=3,
                             baz='second hand',
                             unpack_outcomes=[
-                                dict(type=unpacked_type.id,
+                                dict(type=unpacked_type.code,
                                      quantity=2,
                                      forward_properties=['bar', 'baz']
                                      )
@@ -387,12 +389,12 @@ class TestUnpack(WmsTestCase):
     def test_partial_plan_execute(self):
         """Plan a partial Unpack (uniform scenario), then execute it
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 uniform_outcomes=True,
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=6,
                          ),
                 ],
@@ -452,12 +454,12 @@ class TestUnpack(WmsTestCase):
     def test_partial_cancel(self):
         """Plan a partial Unpack (uniform scenario), then cancel it
         """
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 uniform_outcomes=True,
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=6,
                          ),
                 ],
@@ -522,12 +524,12 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(list(exc_kwargs.get('inputs')), [self.packs])
 
     def test_repr(self):
-        unpacked_type = self.Goods.Type.insert(label="Unpacked")
+        unpacked_type = self.Goods.Type.insert(code='Unpacked')
         self.create_packs(
             type_behaviours=dict(unpack=dict(
                 uniform_outcomes=True,
                 outcomes=[
-                    dict(type=unpacked_type.id,
+                    dict(type=unpacked_type.code,
                          quantity=6,
                          ),
                 ]),

--- a/anyblok_wms_base/quantity/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_unpack.py
@@ -27,6 +27,7 @@ class TestUnpack(WmsTestCase):
     def create_packs(self, type_behaviours=None, properties=None, quantity=5):
         self.packed_goods_type = self.Goods.Type.insert(
             label="Pack",
+            code='PCK',
             behaviours=type_behaviours)
         self.arrival = self.Operation.Arrival.create(
             goods_type=self.packed_goods_type,

--- a/anyblok_wms_base/quantity/tests/test_location.py
+++ b/anyblok_wms_base/quantity/tests/test_location.py
@@ -20,7 +20,8 @@ class TestLocation(WmsTestCase):
 
         self.Goods = Wms.Goods
         self.Avatar = Wms.Goods.Avatar
-        self.goods_type = self.Goods.Type.insert(label="My goods")
+        self.goods_type = self.Goods.Type.insert(label="My goods",
+                                                 code='MyGT')
         self.stock = Wms.Location.insert(label="Stock", code='STK')
         self.arrival = Wms.Operation.Arrival.insert(
             goods_type=self.goods_type,

--- a/anyblok_wms_base/reservation/tests/test_reservation.py
+++ b/anyblok_wms_base/reservation/tests/test_reservation.py
@@ -18,7 +18,8 @@ class ReservationTestCase(WmsTestCase):
         self.Operation = Wms.Operation
         self.Reservation = Wms.Reservation
 
-        self.goods_type = Wms.Goods.Type.insert(label="My good type")
+        self.goods_type = Wms.Goods.Type.insert(label="My good type",
+                                                code="MyGT")
         self.incoming_loc = Wms.Location.insert(label="Incoming location")
         self.stock = Wms.Location.insert(label="Stock")
 

--- a/anyblok_wms_base/testing.py
+++ b/anyblok_wms_base/testing.py
@@ -93,7 +93,8 @@ class WmsTestCaseWithGoods(WmsTestCase):
 
         Wms = self.registry.Wms
         Operation = Wms.Operation
-        self.goods_type = Wms.Goods.Type.insert(label="My good type")
+        self.goods_type = Wms.Goods.Type.insert(label="My good type",
+                                                code='MyGT')
         self.incoming_loc = Wms.Location.insert(label="Incoming location")
         self.stock = Wms.Location.insert(label="Stock")
 


### PR DESCRIPTION
Uniformisation of using the Goods Type codes (instead of id) in Operation behaviours (was already done in Assembly, had to be done in Unpack).

Made the Goods Type codes required and unique.