### PR TITLE
Renamed the 'unpack_outcomes' Property

### DIFF
--- a/anyblok_wms_base/constants.py
+++ b/anyblok_wms_base/constants.py
@@ -90,3 +90,14 @@ DEFAULT_ASSEMBLY_NAME = 'default'
 See :class:`Wms.Operation.Assembly
 <anyblok_wms_base.core.operation.assembly>` for more detail.
 """
+
+CONTENTS_PROPERTY = 'contents'
+"""Standard property used for containing Goods.
+
+This is used in :ref:`Unpack Operation <op_unpack>` to specify variable
+expected outcomes, i.e., those that aren't specified by the
+:ref:`Type behaviour <goods_behaviours>`.
+
+This is also used in the :ref:`Assembly Operation <op_assembly>` to record the
+components of the outcome.
+"""

--- a/anyblok_wms_base/core/goods/goods.py
+++ b/anyblok_wms_base/core/goods/goods.py
@@ -254,7 +254,7 @@ class Properties:
     while being indifferent of the values.
 
     .. note:: the core also makes use of a few special properties, such as
-              ``unpack_outcomes``. TODO make a list, in the form of
+              ``contents``. TODO make a list, in the form of
               constants in a module
     """
 

--- a/anyblok_wms_base/core/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/core/operation/tests/test_unpack.py
@@ -151,7 +151,7 @@ class TestUnpack(WmsTestCase):
             )),
             properties=dict(foo=3,
                             baz='second hand',
-                            unpack_outcomes=[
+                            contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=2,
                                      properties=dict(direct='hop',
@@ -195,7 +195,7 @@ class TestUnpack(WmsTestCase):
             )),
             properties=dict(foo=3,
                             bar='yes',
-                            unpack_outcomes=[
+                            contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=1,
                                      local_goods_ids=[outcome1.id],
@@ -238,7 +238,7 @@ class TestUnpack(WmsTestCase):
             )),
             properties=dict(foo=3,
                             bar='yes',
-                            unpack_outcomes=[
+                            contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=2,
                                      local_goods_ids=[outcome1.id],
@@ -340,7 +340,7 @@ class TestUnpack(WmsTestCase):
             )),
             properties=dict(foo=3,
                             baz='second hand',
-                            unpack_outcomes=[
+                            contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=2,
                                      forward_properties=['bar', 'baz']

--- a/anyblok_wms_base/core/operation/unpack.py
+++ b/anyblok_wms_base/core/operation/unpack.py
@@ -10,6 +10,7 @@
 from anyblok import Declarations
 from anyblok.column import Integer
 
+from anyblok_wms_base.constants import CONTENTS_PROPERTY
 from anyblok_wms_base.exceptions import OperationInputsError
 
 register = Declarations.register
@@ -29,7 +30,7 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
 
     Which Goods will get created and which Properties they will bear is
     specified in the ``unpack`` behaviour of the Type of the Goods being
-    unpacked, together with their ``unpack_outcomes`` optional Properties.
+    unpacked, together with their ``contents`` optional Properties.
     See :meth:`get_outcome_specs` and :meth:`forward_props` for details
     about these and how to achieve the wished functionality.
 
@@ -159,7 +160,7 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
             present or future Avatar for these Goods, and therefore the
             Properties of outcome should not have diverged from the contents
             of ``properties`` since the spec (which must itself not come from
-            the behaviour, but instead from ``unpack_outcomes``) has been
+            the behaviour, but instead from ``contents``) has been
             created (typically by an Assembly).
         * ``required_properties``:
             list (or iterable) of properties that are required on
@@ -214,7 +215,7 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
         Unless ``uniform_outcomes`` is set to ``True`` in the behaviour,
         the outcomes of the Unpack are obtained by merging those defined in
         the behaviour (under the ``outcomes`` key) and in the
-        packs (``self.input``) ``unpack_outcomes`` Property.
+        packs (``self.input``) ``contents`` Property.
 
         This accomodates various use cases:
 
@@ -242,7 +243,7 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
 
         - at toplevel of the behaviour (``uniform_outcomes=True``)
         - in each outcome of the behaviour (``outcomes`` key)
-        - in each outcome of the Goods record (``unpack_outcomes`` property)
+        - in each outcome of the Goods record (``contents`` property)
 
         Here's a use-case: imagine the some purchase order reference is
         tracked as property ``po_ref`` (could be important for accounting).
@@ -271,7 +272,7 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
                 outcome['forward_properties'] = 'clone'
             return specs
 
-        specific_outcomes = packs.get_property('unpack_outcomes', ())
+        specific_outcomes = packs.get_property(CONTENTS_PROPERTY, ())
         specs.extend(specific_outcomes)
         if not specs:
             raise OperationInputsError(

--- a/anyblok_wms_base/quantity/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_unpack.py
@@ -152,7 +152,7 @@ class TestUnpack(WmsTestCase):
             )),
             properties=dict(foo=3,
                             baz='second hand',
-                            unpack_outcomes=[
+                            contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=2,
                                      forward_properties=['bar', 'baz']
@@ -192,7 +192,7 @@ class TestUnpack(WmsTestCase):
             )),
             properties=dict(foo=3,
                             baz='yes',
-                            unpack_outcomes=[
+                            contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=2,
                                      local_goods_ids=[existing.id],
@@ -233,7 +233,7 @@ class TestUnpack(WmsTestCase):
             )),
             properties=dict(foo=3,
                             baz='yes',
-                            unpack_outcomes=[
+                            contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=2,
                                      local_goods_ids=[existing.id],
@@ -338,7 +338,7 @@ class TestUnpack(WmsTestCase):
             )),
             properties=dict(foo=3,
                             baz='second hand',
-                            unpack_outcomes=[
+                            contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=2,
                                      forward_properties=['bar', 'baz']

--- a/doc/apidoc/bloks/wms_core/operation/transforming.rst
+++ b/doc/apidoc/bloks/wms_core/operation/transforming.rst
@@ -90,7 +90,7 @@ Model.Wms.Operation.Assembly
       <h3>Specific members</h3>
 
    .. autoattribute:: specification
-   .. autoattribute:: DEFAULT_FOR_UNPACK_OUTCOMES
+   .. autoattribute:: DEFAULT_FOR_CONTENTS
    .. automethod:: build_outcome_properties
    .. automethod:: eval_typed_expr
    .. automethod:: eval_spec_exprs

--- a/doc/improvements.rst
+++ b/doc/improvements.rst
@@ -187,7 +187,7 @@ to substitute a planned operation with a chain of operations.
   are Goods in 'future' state in the unpacking area.
 * Upon actual delivery, say of three parcels (each with a list of its
   contents), the system would issue three Arrivals (id=``2,3,4``) with
-  ``unpack_outcomes`` storing the theoretical contents, and
+  ``contents`` storing the theoretical contents, and
   link them to the Purchase Order
 * The system would recognize that this Purchase Order is already
   linked to the first planned Arrival (``id=1``), and it would


### PR DESCRIPTION
This is to reflect that it's now more than just the outcomes of Unpack:
it's a listing of the Goods record specific contents.

Also, it's been turned into the CONTENTS_PROPERTY constant