### PR TITLE
Using SharedDataTestCase

### DIFF
--- a/anyblok_wms_base/core/operation/tests/test_departure.py
+++ b/anyblok_wms_base/core/operation/tests/test_departure.py
@@ -119,3 +119,6 @@ class TestDeparture(WmsTestCaseWithGoods):
                                     input=self.avatar)
         repr(dep)
         str(dep)
+
+
+del WmsTestCaseWithGoods

--- a/anyblok_wms_base/core/operation/tests/test_move.py
+++ b/anyblok_wms_base/core/operation/tests/test_move.py
@@ -83,3 +83,6 @@ class TestMove(WmsTestCaseWithGoods):
         move.execute()  # result already tested
         move.obliviate()
         self.assertBackToBeginning()
+
+
+del WmsTestCaseWithGoods

--- a/anyblok_wms_base/core/operation/tests/test_single_input.py
+++ b/anyblok_wms_base/core/operation/tests/test_single_input.py
@@ -89,3 +89,6 @@ class TestSingleInputOperation(WmsTestCaseWithGoods):
         self.assertEqual(exc.model_name, self.op_model_name)
         self.assertEqual(list(exc.kwargs.get('inputs')), [self.avatar])
         self.assertEqual(exc.kwargs.get('record'), self.avatar)
+
+
+del WmsTestCaseWithGoods

--- a/anyblok_wms_base/core/tests/test_exceptions.py
+++ b/anyblok_wms_base/core/tests/test_exceptions.py
@@ -58,3 +58,6 @@ class TestOperationError(WmsTestCaseWithGoods):
 
         repr(err)
         str(err)
+
+
+del WmsTestCaseWithGoods

--- a/anyblok_wms_base/core/tests/test_testing.py
+++ b/anyblok_wms_base/core/tests/test_testing.py
@@ -23,3 +23,6 @@ class TestWmsTestCase(WmsTestCaseWithGoods):
                              (('a', 3), ('batch', None), ('c', 'ok')))
         with self.assertRaises(self.failureException):
             self.sorted_props(goods.type)
+
+
+del WmsTestCaseWithGoods

--- a/anyblok_wms_base/quantity/operation/tests/test_departure.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_departure.py
@@ -15,10 +15,7 @@ class TestDeparture(WmsTestCaseWithGoods):
 
     def setUp(self):
         super(TestDeparture, self).setUp()
-        Wms = self.registry.Wms
-        Operation = Wms.Operation
-        self.stock = Wms.Location.insert(label="Stock")
-        self.Departure = Operation.Departure
+        self.Departure = self.Operation.Departure
 
     def assertQuantities(self, loc=None, **quantities):
         if loc is None:
@@ -95,3 +92,6 @@ class TestDeparture(WmsTestCaseWithGoods):
                                     input=self.avatar)
         repr(dep)
         str(dep)
+
+
+del WmsTestCaseWithGoods

--- a/anyblok_wms_base/quantity/operation/tests/test_move.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_move.py
@@ -19,7 +19,6 @@ class TestMove(WmsTestCaseWithGoods):
         Operation = Wms.Operation
         self.stock = Wms.Location.insert(label="Stock")
 
-        # avatars, actually
         self.avatar.dt_until = self.dt_test3
         self.Move = Operation.Move
 
@@ -80,3 +79,6 @@ class TestMove(WmsTestCaseWithGoods):
         self.assertEqual(after_move.dt_until, self.dt_test3)
         self.assertEqual(after_move.reason, move)
         self.assertEqual(after_move.state, 'present')
+
+
+del WmsTestCaseWithGoods

--- a/anyblok_wms_base/quantity/operation/tests/test_split.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_split.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-from anyblok_wms_base.testing import WmsTestCase
+from anyblok_wms_base.testing import WmsTestCaseWithGoods
 
 from anyblok_wms_base.constants import (
     SPLIT_AGGREGATE_PHYSICAL_BEHAVIOUR
@@ -17,7 +17,7 @@ from anyblok_wms_base.exceptions import (
     )
 
 
-class TestSplit(WmsTestCase):
+class TestSplit(WmsTestCaseWithGoods):
     """Specific testing of Wms.Operation.Split
 
     This may look very partial, but most of the testing of Split is
@@ -28,23 +28,12 @@ class TestSplit(WmsTestCase):
     testcase so that Split can have an independent development life.
     """
 
+    arrival_kwargs = dict(quantity=3)
+    """Used in setUpSharedData()."""
+
     def setUp(self):
         super(TestSplit, self).setUp()
-        Wms = self.registry.Wms
-        self.Operation = Operation = Wms.Operation
-        self.Goods = Wms.Goods
-        self.goods_type = Wms.Goods.Type.insert(label="My good type",
-                                                code='MyGT')
-        self.incoming_loc = Wms.Location.insert(label="Incoming location")
-        self.stock = Wms.Location.insert(label="Stock")
-
-        self.arrival = Operation.Arrival.create(goods_type=self.goods_type,
-                                                location=self.incoming_loc,
-                                                state='planned',
-                                                dt_execution=self.dt_test1,
-                                                quantity=3)
-        self.avatar = self.assert_singleton(self.arrival.outcomes)
-        self.goods = self.avatar.goods
+        self.Operation = self.registry.Wms.Operation
 
     def test_create_done(self):
         self.avatar.state = 'present'
@@ -247,3 +236,6 @@ class TestSplit(WmsTestCase):
         self.assertEqual(restored_goods.type, self.goods.type)
         self.assertEqual(restored_goods.quantity, 3)
         self.assertEqual(restored_goods.properties, self.goods.properties)
+
+
+del WmsTestCaseWithGoods

--- a/anyblok_wms_base/quantity/operation/tests/test_splitter.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_splitter.py
@@ -6,39 +6,25 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-from anyblok_wms_base.testing import WmsTestCase
+from anyblok_wms_base.testing import WmsTestCaseWithGoods
 from anyblok_wms_base.exceptions import (
     OperationQuantityError,
     OperationMissingQuantityError,
 )
 
 
-class TestSplitterOperation(WmsTestCase):
+class TestSplitterOperation(WmsTestCaseWithGoods):
     """Test the WmsSingleGoodOperation mixin
 
     In these test cases, Operation.Move is considered the canonical example of
     the mixin.
     """
+    arrival_kwargs = dict(quantity=3)
+    """Used in setUpSharedData()."""
+
     def setUp(self):
         super(TestSplitterOperation, self).setUp()
-        Wms = self.registry.Wms
-        Operation = Wms.Operation
-        self.goods_type = Wms.Goods.Type.insert(label="My good type",
-                                                code='MyGT')
-        self.incoming_loc = Wms.Location.insert(label="Incoming location")
-        self.stock = Wms.Location.insert(label="Stock")
-
-        self.arrival = Operation.Arrival.create(goods_type=self.goods_type,
-                                                location=self.incoming_loc,
-                                                state='planned',
-                                                dt_execution=self.dt_test1,
-                                                quantity=3)
-
-        self.avatar = self.assert_singleton(self.arrival.outcomes)
-        self.goods = self.avatar.goods
-
-        self.Move = Operation.Move
-        self.Goods = Wms.Goods
+        self.Move = self.Operation.Move
         self.op_model_name = 'Model.Wms.Operation.Move'
 
     def test_missing_quantity(self):
@@ -137,3 +123,6 @@ class TestSplitterOperation(WmsTestCase):
                                 input=self.avatar)
         repr(move)
         str(move)
+
+
+del WmsTestCaseWithGoods

--- a/anyblok_wms_base/sdtestcase.py
+++ b/anyblok_wms_base/sdtestcase.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# This file is a part of the AnyBlok / WMS Base project
+#
+#    Copyright (C) 2018 Georges Racinet <gracinet@anybox.fr>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+"""This module contains unreleased AnyBlok test helpers.
+
+This will allow us to use and refine them before they are properly
+released within AnyBlok.
+"""
+from sqlalchemy import event
+from anyblok.tests.testcase import BlokTestCase
+
+
+class SharedDataTestCase(BlokTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(SharedDataTestCase, cls).setUpClass()
+        cls.pre_data_savepoint = cls.registry.begin_nested()
+        try:
+            cls.setUpSharedData()
+        except Exception as exc:  # pragma: no cover
+            # this code path is tested in the unreleased AnyBlok version
+            # but of course no anyblok_wms_base test has such errors
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def setUpSharedData(cls):
+        """To be implemented by concrete test classes."""
+
+    @classmethod
+    def make_testcase_savepoint(cls, session=None):
+        if session is None:
+            session = cls.registry
+        cls.testcase_savepoint = session.begin_nested()
+
+    def setUp(self):
+        # we don't want to execute BlokTestCase.setUp(), only its parent's:
+        super(BlokTestCase, self).setUp()
+        # tearDown is not called in case of errors in setUp, but these are:
+        self.addCleanup(self.callCleanUp)
+        self.make_testcase_savepoint()
+
+        @event.listens_for(self.registry.session, "after_transaction_end")
+        def restart_savepoint(session, transaction):
+            session.expire_all()
+            if transaction is self.testcase_savepoint:
+                self.make_testcase_savepoint()
+        self.savepoint_restarter = restart_savepoint
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.pre_data_savepoint.rollback()
+        super(SharedDataTestCase, cls).tearDownClass()
+
+    def tearDown(self):
+        """Roll back the session """
+        super(BlokTestCase, self).tearDown()
+        self.testcase_savepoint.rollback()
+        self.registry.System.Cache.invalidate_all()
+        event.remove(self.registry.session, "after_transaction_end",
+                     self.savepoint_restarter)
+        self._transaction_case_teared_down = True


### PR DESCRIPTION
WmsTestCaseWithGoods becomes a SharedDataTestCase, so that the goods
records, the arrival etc are only created once per test class.
This is in advance of Anyblok, to help mature it.

In each test module, we have to delete the imported base class at the
end, otherwise Nose sees it, transplant it in the surrounding module
(making a copy to share a potential setup_module) and executes its
setUpClass even though it bears no concrete test.