### PR TITLE
Assembly instance spec

### DIFF
--- a/anyblok_wms_base/core/operation/assembly.py
+++ b/anyblok_wms_base/core/operation/assembly.py
@@ -693,7 +693,7 @@ class Assembly(Operation):
         to perform custom logic, through :meth:`assembly-specific hooks
         <specific_outcome_properties>`
         """
-        return self.outcome_type.behaviours['assembly'][self.name]
+        return self.outcome_type.get_behaviour('assembly')[self.name]
 
     DEFAULT_FOR_CONTENTS = ('extra', 'records')
     """Default value of the ``for_contents`` part of specification.

--- a/anyblok_wms_base/utils.py
+++ b/anyblok_wms_base/utils.py
@@ -111,6 +111,14 @@ def dict_merge(first, second, list_merge=None, path=()):
       ...                        (1, 'y'): 'append'})
       [{'x': 'a'}, {'y': [2, 1]}, {'x': 1}]
 
+    List paths can use the '*' wildcard:
+
+      >>> dict_merge([dict(y=['a']), dict(y=[1]), {}],
+      ...            [dict(y=['b']), dict(y=[2]), dict(y=3)],
+      ...            list_merge={(): 'zip',
+      ...                        ('*', 'y'): 'append'})
+      [{'y': ['b', 'a']}, {'y': [2, 1]}, {'y': 3}]
+
     Non dict values::
 
       >>> dict_merge(1, 2)
@@ -153,6 +161,10 @@ def _dict_list_merge(first, second, list_merge=None, path=()):
             return first
 
         lm = list_merge.get(path)
+        if lm is None:  # retry with wildcards instead of list indices
+            path = tuple('*' if isinstance(x, int) else x
+                         for x in path)
+            lm = list_merge.get(path)
         if lm == 'zip':
             return [dict_merge(x, y,
                                list_merge=list_merge,

--- a/doc/apidoc/bloks/wms_core/operation/transforming.rst
+++ b/doc/apidoc/bloks/wms_core/operation/transforming.rst
@@ -84,6 +84,7 @@ Model.Wms.Operation.Assembly
    .. autoattribute:: id
    .. autoattribute:: outcome_type
    .. autoattribute:: name
+   .. autoattribute:: parameters
    .. autoattribute:: match
 
    .. raw:: html


### PR DESCRIPTION
This gives Assemblies specific parameters
that get merged with those from the Goods Type's behaviour

Also, we introduce matching of inputs' Goods by id and code.
This is useful for callers (typically planners) that know them
before hand, and allow them to pin the inputs from the very
beginning, without bypassing the various checks imposed from
the Goods Type.

Matching by Goods code and especially id would be useless for the specification on the Goods Type,
but becomes useful with the instance specific parameters.

Note that a planner could also create an Assembly with a pre baked `match` parameter, but this
wouldn't behave well in case the input avatars change, whereas Goods `id` and `code` matching can be done again if needed (one day we'll maybe have a generic method to change an Operation input avatar, so that Operations can be adapted to, e.g, later inserted Moves due to in-between tidying).



 