### PR TITLE
Type recursive queries

### DIFF
--- a/anyblok_wms_base/core/goods/tests/test_type.py
+++ b/anyblok_wms_base/core/goods/tests/test_type.py
@@ -172,3 +172,13 @@ class TestGoodsType(BlokTestCase):
         self.assertTrue(child.has_property_values(dict(foo=2, bar=True)))
         self.assertEqual(child.merged_properties(),
                          dict(foo=2, qa='nok', bar=True))
+
+    def test_query_behaviour(self):
+        parent = self.Type.insert(code='parent',
+                                  behaviours=dict(foo=1))
+        child = self.Type.insert(code='child',
+                                 parent=parent,
+                                 behaviours=dict(bar=2))
+        self.assertEqual(set(self.Type.query_behaviour('foo').all()),
+                         {parent, child})
+        self.assertEqual(self.Type.query_behaviour('bar').one(), child)

--- a/doc/apidoc/core/goods.rst
+++ b/doc/apidoc/core/goods.rst
@@ -38,7 +38,11 @@ Model.Wms.Goods.Type
 
       <h3>Methods</h3>
 
+   .. automethod:: is_sub_type
+   .. automethod:: query_subtypes
    .. automethod:: get_behaviour
+   .. automethod:: query_behaviour
+
 
 
 Model.Wms.Goods.Properties


### PR DESCRIPTION
This PR adds recursive querying to Wms.Goods.Type: descendents of a given Type and Types having a given behaviour.

This can be used, e.g., for additional filtering in `Wms.quantity()` and the like.
Comments and further suggestions welcome!