### PR TITLE
Grouped quantity queries

### DIFF
--- a/anyblok_wms_base/core/physobj/tests/test_containers.py
+++ b/anyblok_wms_base/core/physobj/tests/test_containers.py
@@ -86,7 +86,7 @@ class TestContainers(WmsTestCase):
 
     def test_flatten_subquery_moved(self):
         """Test the flatten subquery with planned Move of containers."""
-        Goods = self.PhysObj
+        PhysObj = self.PhysObj
         stock = self.stock
         loc = self.insert_location('sub', parent=stock)
         loc_av = self.Avatar.query().filter_by(goods=loc).one()
@@ -97,9 +97,9 @@ class TestContainers(WmsTestCase):
                                               dt_execution=self.dt_test2)
 
         def assert_results(expected, **kwargs):
-            cte = Goods.flatten_containers_subquery(**kwargs)
+            cte = PhysObj.flatten_containers_subquery(**kwargs)
             self.assertEqual(
-                set(Goods.query().join(cte, cte.c.id == Goods.id).all()),
+                set(PhysObj.query().join(cte, cte.c.id == PhysObj.id).all()),
                 expected)
 
         # starting point, just to check

--- a/anyblok_wms_base/core/tests/test_wms.py
+++ b/anyblok_wms_base/core/tests/test_wms.py
@@ -13,7 +13,7 @@ from anyblok_wms_base.testing import BlokTestCase
 class TestWms(BlokTestCase):
     """Test Model.Wms methods not related to quantities.
 
-    For quantities of physical objects, see :mod:`test_goods_quantities`.
+    For quantities of physical objects, see :mod:`test_quantity`.
     """
 
     def setUp(self):

--- a/anyblok_wms_base/core/wms.py
+++ b/anyblok_wms_base/core/wms.py
@@ -31,19 +31,20 @@ class Wms:
     """
 
     @classmethod
-    def quantity(cls,
-                 goods_type=None,
-                 additional_states=None,
-                 at_datetime=None,
-                 additional_filter=None,
-                 location=None,
-                 location_recurse=True):
-        """Compute the quantity of PhysObj meeting various criteria.
+    def quantity_query(cls,
+                       goods_type=None,
+                       additional_states=None,
+                       at_datetime=None,
+                       additional_filter=None,
+                       location=None,
+                       location_recurse=True):
+        """Query computing the quantity of PhysObj meeting various criteria.
 
         The computation actually involves querying :class:`Avatars
         <anyblok_wms_base.core.physobj.Avatar>`, which hold the
         information about location, states and date/time.
 
+        :return: Query object, with only one column (the quantity)
         :param goods_type:
             if specified, restrict computation to PhysObj of this type
         :param location:
@@ -141,15 +142,82 @@ class Wms:
                                      Avatar.dt_until > at_datetime))
         if additional_filter is not None:
             query = additional_filter(query)
+        return query
+
+    @classmethod
+    def quantity(cls, **kwargs):
+        """Compute the quantity of PhysObj meeting various criteria.
+
+        This method executes :meth:`quantity_query` and returns the resulting
+        numeric value.
+        """
+        query = cls.quantity_query(**kwargs)
         res = query.one()[0]
         return 0 if res is None else res
 
     @classmethod
+    def grouped_quantity_query(
+            cls, joined=False, by_location=True, by_type=True,
+            **kwargs):
+        """Build a query to count quantities, grouped by Type and location.
+
+        The grouping by location / container is about direct locations,
+        independently of the fact that the query is able to recursively
+        restrict to a given top location.
+
+        :param bool by_location: controls grouping by location
+        :param bool by_type: controls grouping by type
+        :param bool joined: if ``True``, joins on Wms.PhysObj (for locations)
+                            and Wms.PhysObj.Type are performed, so that result
+                            columns contain instances of these Models;
+                            otherwise, these columns have just ids
+        :param kwargs: all other keyword arguments are passed to
+                       :meth:`quantity_query`
+        :return: a Query object, whose result columns are:
+                   - count
+                   - (optionally) location (Wms.PhysObj or id)
+                   - (optionally) type (Wms.PhysObj.Type or id)
+        """
+        PhysObj = cls.registry.Wms.PhysObj
+        query = cls.quantity_query(**kwargs)
+        Avatar = PhysObj.Avatar
+        if not joined:
+            cols = []
+            if by_location:
+                cols.append(Avatar.location_id)
+            if by_type:
+                cols.append(PhysObj.type_id)
+            return query.add_columns(*cols).group_by(*cols)
+
+        # as of now, base_quantity_query() does not produce joins
+        # onto Location nor Type, only WHERE closes on ids of these (the CTE
+        # does not count, as it produces ids only)
+        # TODO try and detect and use JOINs introduced by additional filters ?
+        if by_location:
+            Location = orm.aliased(PhysObj, name='location')
+            query = query.add_entity(Location).join(
+                Location, Avatar.location_id == Location.id).group_by(Location)
+        if by_type:
+            PT = PhysObj.Type
+            query = query.add_entity(PT).join(PhysObj.type).group_by(PT)
+
+        return query
+
+    @classmethod
     def base_quantity_query(cls):
-        """Return base join query, without any filtering
+        """Return base join quantity query, without any filtering
+
+        This is the starting point of all quantity queries, and is not meant
+        for direct use.
+
+        The intent of separating this method is to make it overridable,
+        which is done in particular by the :ref:`wms-quantity
+        <blok_wms_quantity>` blok.
 
         :return: The query is assumed to produce exactly one row, with the
                  wished quantity result (possibly ``None`` for 0)
+                 TODO change that using COALESCE where needed (less special
+                 cases to define and test in Python code)
         """
         Avatar = cls.PhysObj.Avatar
         return Avatar.query(func.count(Avatar.id)).join(Avatar.obj)

--- a/anyblok_wms_base/quantity/wms.py
+++ b/anyblok_wms_base/quantity/wms.py
@@ -16,7 +16,7 @@ class Wms:
 
     @classmethod
     def base_quantity_query(cls):
-        """Return a base query fit for summing PhysObj.Quantity."""
+        """Return a base query fit for summing PhysObj.quantity."""
         PhysObj = cls.registry.Wms.PhysObj
         Avatar = PhysObj.Avatar
         # TODO distinguish quantity on Avatars from those on PhysObj?

--- a/doc/apidoc/core/wms.rst
+++ b/doc/apidoc/core/wms.rst
@@ -14,6 +14,13 @@ Model.Wms
 
    .. automethod:: create_root_container
    .. automethod:: quantity
-   .. automethod:: base_quantity_query
+   .. automethod:: quantity_query
+   .. automethod:: grouped_quantity_query
    .. automethod:: filter_container_types
    .. automethod:: exclude_container_types
+
+   .. raw:: html
+
+      <h3>Internal methods</h3>
+
+    .. automethod:: base_quantity_query

--- a/doc/apidoc/tests.rst
+++ b/doc/apidoc/tests.rst
@@ -7,6 +7,6 @@ provide useful examples.
 This page is therefore by no means comprehensive. If a given test
 class is listed here, only its interesting test cases are.
 
-.. autoclass:: anyblok_wms_base.core.physobj.tests.test_containers.TestContainers
+.. autoclass:: anyblok_wms_base.core.tests.test_quantity.TestQuantity
 
    .. automethod:: test_override_recursion


### PR DESCRIPTION
`Wms.grouped_quantity_query()` provides the stock levels, grouped by type and container/location, with the same subhierarchy filering capabiliies as  `Wms.quantity()`.

Work in progress, will have to be adapted if it lands after #17, of course, and I intend to regroup in fewer commits (tests reorgs, then the new feature)