### PR TITLE
Default value for date&time of execution of planned Operations

### DIFF
--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -16,6 +16,7 @@ Release history
   one: ``Wms.PhysObj``. This impacts all existing code bases.
 * Inventory Operations: Apparition, Disparition and Teleportation
 * Enrichment of Properties API
+* The date and time of ``planned`` Operations is no longer mandatory
 
 0.7.0
 ~~~~~


### PR DESCRIPTION
This gives issue #20 a simple solution, by accepting to have very fictive date and times in planned Operations and future Avatars rather than forcing it onto the applicative developer to make the very same decisions.

The PR includes a discussion of a better way of doing, as a section in the "Improvements" parts of the documentaion, and that is deeply related to issue #8