### PR TITLE
Renaming of the goods_type/code/etc. fields of Operations

### DIFF
--- a/anyblok_wms_base/__init__.py
+++ b/anyblok_wms_base/__init__.py
@@ -7,4 +7,4 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
-version = '0.9.0.dev0'
+version = '0.9.0.dev1'

--- a/anyblok_wms_base/core/__init__.py
+++ b/anyblok_wms_base/core/__init__.py
@@ -80,6 +80,7 @@ class WmsCore(Blok):
         execute = self.registry.execute
         for op, suffixes in (
                 ('arrival', ('type_id', 'properties', 'code')),
+                ('apparition', ('type_id', 'properties', 'code')),
         ):
             for suffix in suffixes:
                 execute("ALTER TABLE wms_operation_{op} "

--- a/anyblok_wms_base/core/__init__.py
+++ b/anyblok_wms_base/core/__init__.py
@@ -35,6 +35,8 @@ class WmsCore(Blok):
             return
         if latest_version < '0.8.0.dev1':
             self.migr_physobj()
+        if latest_version < '0.9.0.dev1':
+            self.migr_ops_physobj_cols()
 
     def migr_physobj(self):  # pragma: no cover
         logger.info("Premigration: renaming of Goods to PhysObj")
@@ -71,6 +73,18 @@ class WmsCore(Blok):
         # delete and recreate them, that's not an issue with current volumes
         # but it would be at a later stage of development
         # TODO provide AnyBlok facilities for migrations that are just renames
+
+    def migr_ops_physobj_cols(self):  # pragma: no cover
+        logger.info("Premigration: renaming of goods_* columns of Operations "
+                    "to physobj_*")
+        execute = self.registry.execute
+        for op, suffixes in (
+                ('arrival', ('type_id', 'properties', 'code')),
+        ):
+            for suffix in suffixes:
+                execute("ALTER TABLE wms_operation_{op} "
+                        "RENAME COLUMN goods_{suffix} "
+                        "TO physobj_{suffix}".format(op=op, suffix=suffix))
 
     @classmethod
     def import_declaration_module(cls):

--- a/anyblok_wms_base/core/operation/apparition.py
+++ b/anyblok_wms_base/core/operation/apparition.py
@@ -9,9 +9,10 @@
 from anyblok import Declarations
 from anyblok.column import Integer
 from anyblok.column import Text
+from anyblok.field import Function
 from anyblok_postgres.column import Jsonb
 from anyblok.relationship import Many2One
-
+from .deprecation import deprecation_warn_goods_col
 from anyblok_wms_base.exceptions import (
     OperationForbiddenState,
     OperationContainerExpected,
@@ -38,7 +39,7 @@ class Apparition(Operation):
                  autoincrement=False,
                  foreign_key=Operation.use('id').options(ondelete='cascade'))
     """Primary key."""
-    goods_type = Many2One(model='Model.Wms.PhysObj.Type')
+    physobj_type = Many2One(model='Model.Wms.PhysObj.Type')
     """Observed :class:`PhysObj Type
     <anyblok_wms_base.core.physobj.Type>`.
     """
@@ -47,7 +48,7 @@ class Apparition(Operation):
 
     Here, identical means "same type, code and properties"
     """
-    goods_properties = Jsonb()
+    physobj_properties = Jsonb()
     """Observed :class:`Properties
     <anyblok_wms_base.core.physobj.Properties>`.
 
@@ -56,7 +57,7 @@ class Apparition(Operation):
     the PhysObj, while this Apparition field will keep the exact values
     that were observed during inventory.
     """
-    goods_code = Text()
+    physobj_code = Text()
     """Observed :attr:`PhysObj code
     <anyblok_wms_base.core.physobj.PhysObj.code>`.
     """
@@ -66,12 +67,82 @@ class Apparition(Operation):
     This will be the location of the initial Avatars.
     """
 
+    goods_type = Function(fget='_goods_type_get',
+                          fset='_goods_type_set',
+                          fexpr='_goods_type_expr')
+    """Compatibility wrapper.
+
+    Before version 0.9.0, :attr:`physobj_type` was ``goods_type``.
+
+    This does not extend to compatibility of the former low level
+    ``goods_type_id`` column.
+    """
+
+    goods_properties = Function(fget='_goods_properties_get',
+                                fset='_goods_properties_set',
+                                fexpr='_goods_properties_expr')
+    """Compatibility wrapper.
+
+    Before version 0.9.0, :attr:`physobj_properties` was ``goods_properties``.
+    """
+
+    goods_code = Function(fget='_goods_code_get',
+                          fset='_goods_code_set',
+                          fexpr='_goods_code_expr')
+    """Compatibility wrapper.
+
+    Before version 0.9.0, :attr:`physobj_code` was ``goods_code``.
+    """
+
     inputs_number = 0
     """This Operation is a purely creative one."""
 
     def specific_repr(self):
         return ("goods_type={self.goods_type!r}, "
                 "location={self.location!r}").format(self=self)
+
+    def _goods_col_get(self, suffix):
+        deprecation_warn_goods_col(self, suffix)
+        return getattr(self, 'physobj_' + suffix)
+
+    def _goods_col_set(self, suffix, value):
+        deprecation_warn_goods_col(self, suffix)
+        setattr(self, 'physobj_' + suffix, value)
+
+    @classmethod
+    def _goods_col_expr(cls, suffix):
+        deprecation_warn_goods_col(cls, suffix)
+        return getattr(cls, 'physobj_' + suffix)
+
+    def _goods_type_get(self):
+        return self._goods_col_get('type')
+
+    def _goods_type_set(self, value):
+        self._goods_col_set('type', value)
+
+    @classmethod
+    def _goods_type_expr(cls):
+        return cls._goods_col_expr('type')
+
+    def _goods_properties_get(self):
+        return self._goods_col_get('properties')
+
+    def _goods_properties_set(self, value):
+        self._goods_col_set('properties', value)
+
+    @classmethod
+    def _goods_properties_expr(cls):
+        return cls._goods_col_expr('properties')
+
+    def _goods_code_get(self):
+        return self._goods_col_get('code')
+
+    def _goods_code_set(self, value):
+        self._goods_col_set('code', value)
+
+    @classmethod
+    def _goods_code_expr(cls):
+        return cls._goods_col_expr('code')
 
     @classmethod
     def check_create_conditions(cls, state, dt_execution, location=None,

--- a/anyblok_wms_base/core/operation/apparition.py
+++ b/anyblok_wms_base/core/operation/apparition.py
@@ -98,7 +98,7 @@ class Apparition(Operation):
     """This Operation is a purely creative one."""
 
     def specific_repr(self):
-        return ("goods_type={self.goods_type!r}, "
+        return ("physobj_type={self.physobj_type!r}, "
                 "location={self.location!r}").format(self=self)
 
     def _goods_col_get(self, suffix):
@@ -176,7 +176,7 @@ class Apparition(Operation):
         gives rise to as many PhysObj records.
         """
         PhysObj = self.registry.Wms.PhysObj
-        self_props = self.goods_properties
+        self_props = self.physobj_properties
         if self_props is None:
             props = None
         else:
@@ -185,9 +185,9 @@ class Apparition(Operation):
         for _ in range(self.quantity):
             PhysObj.Avatar.insert(
                 obj=PhysObj.insert(
-                    type=self.goods_type,
+                    type=self.physobj_type,
                     properties=props,
-                    code=self.goods_code),
+                    code=self.physobj_code),
                 location=self.location,
                 outcome_of=self,
                 state='present',

--- a/anyblok_wms_base/core/operation/arrival.py
+++ b/anyblok_wms_base/core/operation/arrival.py
@@ -9,9 +9,10 @@
 from anyblok import Declarations
 from anyblok.column import Integer
 from anyblok.column import Text
+from anyblok.field import Function
 from anyblok_postgres.column import Jsonb
 from anyblok.relationship import Many2One
-
+from .deprecation import deprecation_warn_goods_col
 from anyblok_wms_base.exceptions import (
     OperationError,
     OperationContainerExpected,
@@ -50,11 +51,11 @@ class Arrival(Operation):
                  autoincrement=False,
                  foreign_key=Operation.use('id').options(ondelete='cascade'))
     """Primary key."""
-    goods_type = Many2One(model='Model.Wms.PhysObj.Type')
+    physobj_type = Many2One(model='Model.Wms.PhysObj.Type')
     """Expected :class:`PhysObj Type
     <anyblok_wms_base.core.physobj.Type>`.
     """
-    goods_properties = Jsonb(label="Properties of arrived PhysObj")
+    physobj_properties = Jsonb(label="Properties of arrived PhysObj")
     """Expected :class:`Properties
     <anyblok_wms_base.core.physobj.Properties>`.
 
@@ -64,7 +65,7 @@ class Arrival(Operation):
     reality is the concern of separate validation processes, and this
     field can serve for later assessments after the fact.
     """
-    goods_code = Text(label="Code to set on arrived PhysObj")
+    physobj_code = Text(label="Code to set on arrived PhysObj")
     """Expected :attr:`PhysObj code
     <anyblok_wms_base.core.physobj.PhysObj.code>`.
 
@@ -74,6 +75,33 @@ class Arrival(Operation):
     location = Many2One(model='Model.Wms.PhysObj')
     """Will be the location of the initial Avatar."""
 
+    goods_type = Function(fget='_goods_type_get',
+                          fset='_goods_type_set',
+                          fexpr='_goods_type_expr')
+    """Compatibility wrapper.
+
+    Before version 0.9.0, :attr:`physobj_type` was ``goods_type``.
+
+    This does not extend to compatibility of the former low level
+    ``goods_type_id`` column.
+    """
+
+    goods_properties = Function(fget='_goods_properties_get',
+                                fset='_goods_properties_set',
+                                fexpr='_goods_properties_expr')
+    """Compatibility wrapper.
+
+    Before version 0.9.0, :attr:`physobj_properties` was ``goods_properties``.
+    """
+
+    goods_code = Function(fget='_goods_code_get',
+                          fset='_goods_code_set',
+                          fexpr='_goods_code_expr')
+    """Compatibility wrapper.
+
+    Before version 0.9.0, :attr:`physobj_code` was ``goods_code``.
+    """
+
     inputs_number = 0
     """This Operation is a purely creative one."""
 
@@ -82,6 +110,49 @@ class Arrival(Operation):
     def specific_repr(self):
         return ("goods_type={self.goods_type!r}, "
                 "location={self.location!r}").format(self=self)
+
+    def _goods_col_get(self, suffix):
+        deprecation_warn_goods_col(self, suffix)
+        return getattr(self, 'physobj_' + suffix)
+
+    def _goods_col_set(self, suffix, value):
+        deprecation_warn_goods_col(self, suffix)
+        setattr(self, 'physobj_' + suffix, value)
+
+    @classmethod
+    def _goods_col_expr(cls, suffix):
+        deprecation_warn_goods_col(cls, suffix)
+        return getattr(cls, 'physobj_' + suffix)
+
+    def _goods_type_get(self):
+        return self._goods_col_get('type')
+
+    def _goods_type_set(self, value):
+        self._goods_col_set('type', value)
+
+    @classmethod
+    def _goods_type_expr(cls):
+        return cls._goods_col_expr('type')
+
+    def _goods_properties_get(self):
+        return self._goods_col_get('properties')
+
+    def _goods_properties_set(self, value):
+        self._goods_col_set('properties', value)
+
+    @classmethod
+    def _goods_properties_expr(cls):
+        return cls._goods_col_expr('properties')
+
+    def _goods_code_get(self):
+        return self._goods_col_get('code')
+
+    def _goods_code_set(self, value):
+        self._goods_col_set('code', value)
+
+    @classmethod
+    def _goods_code_expr(cls):
+        return cls._goods_col_expr('code')
 
     @classmethod
     def check_create_conditions(cls, state, dt_execution, location=None,

--- a/anyblok_wms_base/core/operation/arrival.py
+++ b/anyblok_wms_base/core/operation/arrival.py
@@ -108,7 +108,7 @@ class Arrival(Operation):
     destination_field = 'location'
 
     def specific_repr(self):
-        return ("goods_type={self.goods_type!r}, "
+        return ("physobj_type={self.physobj_type!r}, "
                 "location={self.location!r}").format(self=self)
 
     def _goods_col_get(self, suffix):
@@ -167,15 +167,15 @@ class Arrival(Operation):
 
     def after_insert(self):
         PhysObj = self.registry.Wms.PhysObj
-        self_props = self.goods_properties
+        self_props = self.physobj_properties
         if self_props is None:
             props = None
         else:
             props = PhysObj.Properties.create(**self_props)
 
-        goods = PhysObj.insert(type=self.goods_type,
+        goods = PhysObj.insert(type=self.physobj_type,
                                properties=props,
-                               code=self.goods_code)
+                               code=self.physobj_code)
         PhysObj.Avatar.insert(
             obj=goods,
             location=self.location,
@@ -256,9 +256,9 @@ class Arrival(Operation):
             dt_pack_arrival = min(arr.dt_execution for arr in arrivals)
         pack_arr = cls.create(location=location,
                               dt_execution=dt_pack_arrival,
-                              goods_type=pack_type,
-                              goods_properties=pack_properties,
-                              goods_code=pack_code,
+                              physobj_type=pack_type,
+                              physobj_properties=pack_properties,
+                              physobj_code=pack_code,
                               state='planned')
 
         arrivals_outcomes = {arr.outcomes[0]: arr for arr in arrivals}

--- a/anyblok_wms_base/core/operation/assembly.py
+++ b/anyblok_wms_base/core/operation/assembly.py
@@ -890,12 +890,12 @@ class Assembly(Operation):
 
             contents.append(unpack_outcome)
             if how == 'records':
-                # Adding local goods id so that a forthcoming unpack
-                # would produce the very same goods.
+                # Adding physobj id so that a forthcoming unpack
+                # would produce the very same physical objects.
                 # TODO this *must* be discarded in case of Departures with
                 # EDI,  and maybe some other ones. How to do that cleanly and
                 # efficiently ?
-                unpack_outcome['local_goods_ids'] = [goods.id]
+                unpack_outcome['local_physobj_ids'] = [goods.id]
 
         return contents
 

--- a/anyblok_wms_base/core/operation/deprecation.py
+++ b/anyblok_wms_base/core/operation/deprecation.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# This file is a part of the AnyBlok / WMS Base project
+#
+#    Copyright (C) 2018 Georges Racinet <gracinet@anybox.fr>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+import warnings
+
+
+def deprecation_warn_goods_col(op, suffix):
+    """Generic deprecation warning for goods_* columns of various Operations.
+    """
+    warnings.warn(
+        "The 'goods_{suffix}' attribute of {op} is "
+        "deprecated, please rename to 'physobj_{suffix}' before "
+        "version 1.0 of Anyblok / WMS Base".format(op=op.__registry_name__,
+                                                   suffix=suffix),
+        DeprecationWarning,
+        stacklevel=2)

--- a/anyblok_wms_base/core/operation/tests/test_alter_planning.py
+++ b/anyblok_wms_base/core/operation/tests/test_alter_planning.py
@@ -84,6 +84,7 @@ class TestAlterPlanning(WmsTestCaseWithPhysObj):
         # and that's been propagated to the unpack outcomes
         self.assertTrue(all(oc.location == incoming) for oc in unp.outcomes)
         # which haven't changed btw
+        self.MAXDIFF = None
         self.assertEqual(unp.outcomes, unp_outcomes)
 
     def test_inconsistent_alter_destination_before_assembly(self):
@@ -93,7 +94,7 @@ class TestAlterPlanning(WmsTestCaseWithPhysObj):
         arrival2 = self.Operation.Arrival.create(
             location=incoming,
             dt_execution=self.dt_test1,
-            goods_type=self.physobj_type)
+            physobj_type=self.physobj_type)
 
         ass_inputs = [arrival1.outcomes[0], arrival2.outcomes[0]]
 
@@ -219,7 +220,7 @@ class TestAlterPlanning(WmsTestCaseWithPhysObj):
                                                    dt_unpack=None):
         Arrival = self.Operation.Arrival
         arrival, avatar = self.arrival, self.avatar
-        arrival2 = Arrival.create(goods_type=self.physobj_type,
+        arrival2 = Arrival.create(physobj_type=self.physobj_type,
                                   location=self.incoming_loc,
                                   state='planned',
                                   dt_execution=self.dt_test1)
@@ -302,7 +303,7 @@ class TestAlterPlanning(WmsTestCaseWithPhysObj):
         self.assertEqual(exc.kwargs['arrivals'], ())
 
         # different locations
-        arrival2 = Arrival.create(goods_type=self.physobj_type,
+        arrival2 = Arrival.create(physobj_type=self.physobj_type,
                                   location=self.stock,
                                   state='planned',
                                   dt_execution=self.dt_test1)
@@ -334,7 +335,7 @@ class TestAlterPlanning(WmsTestCaseWithPhysObj):
         downstreams = []
         original_avatars = set()
         for i in range(5):
-            arrival = Arrival.create(goods_type=unpacked_type,
+            arrival = Arrival.create(physobj_type=unpacked_type,
                                      location=unpack_area,
                                      state='planned',
                                      dt_execution=self.dt_test2)
@@ -371,7 +372,7 @@ class TestAlterPlanning(WmsTestCaseWithPhysObj):
 
         # here's the final picture
         parcel_arrivals = Arrival.query().filter_by(
-            goods_type=parcel_type).all()
+            physobj_type=parcel_type).all()
         self.assertEqual(len(parcel_arrivals), 2)
         all_unpacks_outcomes = set()
         for arr in parcel_arrivals:

--- a/anyblok_wms_base/core/operation/tests/test_apparition.py
+++ b/anyblok_wms_base/core/operation/tests/test_apparition.py
@@ -20,8 +20,8 @@ class TestApparition(WmsTestCase):
     def setUp(self):
         super(TestApparition, self).setUp()
         Wms = self.registry.Wms
-        self.goods_type = Wms.PhysObj.Type.insert(label="My good type",
-                                                  code='MGT')
+        self.physobj_type = Wms.PhysObj.Type.insert(label="My good type",
+                                                    code='MGT')
         self.stock = self.insert_location('Stock')
         self.Apparition = Wms.Operation.Apparition
         self.PhysObj = Wms.PhysObj
@@ -32,16 +32,16 @@ class TestApparition(WmsTestCase):
             location=self.stock,
             state='done',
             quantity=1,
-            goods_code='x34/7',
-            goods_properties=dict(foo=2,
-                                  monty='python'),
-            goods_type=self.goods_type)
+            physobj_code='x34/7',
+            physobj_properties=dict(foo=2,
+                                    monty='python'),
+            physobj_type=self.physobj_type)
         self.assertEqual(len(apparition.follows), 0)
         avatar = self.assert_singleton(apparition.outcomes)
         goods = avatar.obj
         self.assertEqual(avatar.state, 'present')
         self.assertEqual(avatar.location, self.stock)
-        self.assertEqual(goods.type, self.goods_type)
+        self.assertEqual(goods.type, self.physobj_type)
         self.assertEqual(goods.code, 'x34/7')
         self.assertEqual(goods.get_property('foo'), 2)
         self.assertEqual(goods.get_property('monty'), 'python')
@@ -52,7 +52,7 @@ class TestApparition(WmsTestCase):
         apparition.obliviate()
         self.assertEqual(self.Avatar.query().count(), 0)
         self.assertEqual(
-            self.PhysObj.query().filter_by(type=self.goods_type).count(),
+            self.PhysObj.query().filter_by(type=self.physobj_type).count(),
             0)
 
     def test_create_done_several_obliviate(self):
@@ -60,10 +60,10 @@ class TestApparition(WmsTestCase):
             location=self.stock,
             state='done',
             quantity=3,
-            goods_code='x34/7',
-            goods_properties=dict(foo=2,
-                                  monty='python'),
-            goods_type=self.goods_type)
+            physobj_code='x34/7',
+            physobj_properties=dict(foo=2,
+                                    monty='python'),
+            physobj_type=self.physobj_type)
         self.assertEqual(len(apparition.follows), 0)
         avatars = apparition.outcomes
         self.assertEqual(len(avatars), 3)
@@ -71,7 +71,7 @@ class TestApparition(WmsTestCase):
             goods = avatar.obj
             self.assertEqual(avatar.state, 'present')
             self.assertEqual(avatar.location, self.stock)
-            self.assertEqual(goods.type, self.goods_type)
+            self.assertEqual(goods.type, self.physobj_type)
             self.assertEqual(goods.code, 'x34/7')
             self.assertEqual(goods.get_property('foo'), 2)
             self.assertEqual(goods.get_property('monty'), 'python')
@@ -90,7 +90,7 @@ class TestApparition(WmsTestCase):
         apparition.obliviate()
         self.assertEqual(self.Avatar.query().count(), 0)
         self.assertEqual(
-            self.PhysObj.query().filter_by(type=self.goods_type).count(),
+            self.PhysObj.query().filter_by(type=self.physobj_type).count(),
             0)
 
     def test_create_done_no_props(self):
@@ -98,14 +98,14 @@ class TestApparition(WmsTestCase):
             location=self.stock,
             state='done',
             quantity=1,
-            goods_code='x34/7',
-            goods_type=self.goods_type)
+            physobj_code='x34/7',
+            physobj_type=self.physobj_type)
         self.assertEqual(len(apparition.follows), 0)
         avatar = self.assert_singleton(apparition.outcomes)
         goods = avatar.obj
         self.assertEqual(avatar.state, 'present')
         self.assertEqual(avatar.location, self.stock)
-        self.assertEqual(goods.type, self.goods_type)
+        self.assertEqual(goods.type, self.physobj_type)
         self.assertEqual(goods.code, 'x34/7')
         self.assertIsNone(goods.properties)
 
@@ -117,8 +117,8 @@ class TestApparition(WmsTestCase):
             location=self.stock,
             state='done',
             quantity=1,
-            goods_code='x34/7',
-            goods_type=self.goods_type)
+            physobj_code='x34/7',
+            physobj_type=self.physobj_type)
         with self.assertRaises(OperationIrreversibleError) as arc:
             apparition.plan_revert()
 
@@ -132,22 +132,22 @@ class TestApparition(WmsTestCase):
             self.Apparition.create(location=self.stock,
                                    state='planned',
                                    dt_execution=self.dt_test1,
-                                   goods_code='x34/7',
-                                   goods_properties=dict(foo=2,
-                                                         monty='python'),
-                                   goods_type=self.goods_type)
+                                   physobj_code='x34/7',
+                                   physobj_properties=dict(foo=2,
+                                                           monty='python'),
+                                   physobj_type=self.physobj_type)
         exc = arc.exception
         repr(exc)
         str(exc)
         self.assertEqual(exc.kwargs.get('forbidden'), 'planned')
 
     def test_not_a_container(self):
-        wrong_loc = self.PhysObj.insert(type=self.goods_type)
+        wrong_loc = self.PhysObj.insert(type=self.physobj_type)
         with self.assertRaises(OperationContainerExpected) as arc:
             self.Apparition.create(
                 location=wrong_loc,
                 state='done',
-                goods_type=self.goods_type)
+                physobj_type=self.physobj_type)
         exc = arc.exception
         str(exc)
         repr(exc)
@@ -168,7 +168,7 @@ class TestApparition(WmsTestCase):
                                      physobj_code='765',
                                      physobj_properties=dict(foo=5,
                                                              bar='monty'),
-                                     physobj_type=self.goods_type)
+                                     physobj_type=self.physobj_type)
 
         def assert_warnings_goods_deprecation(got_warnings):
             self.assert_warnings_deprecation(

--- a/anyblok_wms_base/core/operation/tests/test_apparition.py
+++ b/anyblok_wms_base/core/operation/tests/test_apparition.py
@@ -6,7 +6,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-from .testcase import WmsTestCase
+import warnings
+from anyblok_wms_base.testing import WmsTestCase
 from anyblok_wms_base.exceptions import (
     OperationIrreversibleError,
     OperationForbiddenState,
@@ -151,3 +152,54 @@ class TestApparition(WmsTestCase):
         str(exc)
         repr(exc)
         self.assertEqual(exc.kwargs['offender'], wrong_loc)
+
+    def check_compatibility_goods_col(self, suffix, update_value):
+        """Test compatibility function field for the rename goods->obj.
+
+        To be removed together with that function field once the deprecation
+        has expired.
+        """
+        old_field_name = 'goods_' + suffix
+        new_field_name = 'physobj_' + suffix
+        app = self.Apparition.create(location=self.stock,
+                                     state='done',
+                                     quantity=1,
+                                     dt_execution=self.dt_test1,
+                                     physobj_code='765',
+                                     physobj_properties=dict(foo=5,
+                                                             bar='monty'),
+                                     physobj_type=self.goods_type)
+
+        def assert_warnings_goods_deprecation(got_warnings):
+            self.assert_warnings_deprecation(
+                got_warnings, "'%s'" % old_field_name,
+                "rename to '%s'" % new_field_name)
+
+        with warnings.catch_warnings(record=True) as got:
+            # reading
+            self.assertEqual(getattr(app, old_field_name),
+                             getattr(app, new_field_name))
+        assert_warnings_goods_deprecation(got)
+
+        with warnings.catch_warnings(record=True) as got:
+            app.update(**{old_field_name: update_value})
+        assert_warnings_goods_deprecation(got)
+        self.assertEqual(getattr(app, new_field_name), update_value)
+
+        with warnings.catch_warnings(record=True) as got:
+            # querying
+            self.assert_singleton(
+                self.Apparition.query().filter_by(
+                    **{old_field_name: update_value}).all(),
+                value=app)
+        assert_warnings_goods_deprecation(got)
+
+    def test_compatibility_goods_code(self):
+        self.check_compatibility_goods_col('code', 'ABC')
+
+    def test_compatibility_goods_properties(self):
+        self.check_compatibility_goods_col('properties', dict(foo=7))
+
+    def test_compatibility_goods_type(self):
+        pot = self.PhysObj.Type.insert(code='OTHER')
+        self.check_compatibility_goods_col('type', pot)

--- a/anyblok_wms_base/core/operation/tests/test_arrival.py
+++ b/anyblok_wms_base/core/operation/tests/test_arrival.py
@@ -19,8 +19,8 @@ class TestArrival(WmsTestCase):
     def setUp(self):
         super(TestArrival, self).setUp()
         PhysObj = self.PhysObj
-        self.goods_type = PhysObj.Type.insert(label="My good type",
-                                              code='MGT')
+        self.physobj_type = PhysObj.Type.insert(label="My good type",
+                                                code='MGT')
         self.incoming_loc = self.insert_location('INCOMING')
         self.stock = self.insert_location('STOCK')
 
@@ -31,16 +31,16 @@ class TestArrival(WmsTestCase):
         arrival = self.Arrival.create(location=self.incoming_loc,
                                       state='planned',
                                       dt_execution=self.dt_test1,
-                                      goods_code='765',
-                                      goods_properties=dict(foo=5,
-                                                            bar='monty'),
-                                      goods_type=self.goods_type)
+                                      physobj_code='765',
+                                      physobj_properties=dict(foo=5,
+                                                              bar='monty'),
+                                      physobj_type=self.physobj_type)
         self.assertEqual(len(arrival.follows), 0)
         avatar = self.assert_singleton(arrival.outcomes)
         goods = avatar.obj
         self.assertEqual(avatar.state, 'future')
         self.assertEqual(avatar.location, self.incoming_loc)
-        self.assertEqual(goods.type, self.goods_type)
+        self.assertEqual(goods.type, self.physobj_type)
         self.assertEqual(goods.code, '765')
         self.assertEqual(goods.get_property('foo'), 5)
         self.assertEqual(goods.get_property('bar'), 'monty')
@@ -59,16 +59,16 @@ class TestArrival(WmsTestCase):
     def test_create_done(self):
         arrival = self.Arrival.create(location=self.incoming_loc,
                                       state='done',
-                                      goods_code='x34/7',
-                                      goods_properties=dict(foo=2,
-                                                            monty='python'),
-                                      goods_type=self.goods_type)
+                                      physobj_code='x34/7',
+                                      physobj_properties=dict(foo=2,
+                                                              monty='python'),
+                                      physobj_type=self.physobj_type)
         self.assertEqual(len(arrival.follows), 0)
         avatar = self.assert_singleton(arrival.outcomes)
         goods = avatar.obj
         self.assertEqual(avatar.state, 'present')
         self.assertEqual(avatar.location, self.incoming_loc)
-        self.assertEqual(goods.type, self.goods_type)
+        self.assertEqual(goods.type, self.physobj_type)
         self.assertEqual(goods.code, 'x34/7')
         self.assertEqual(goods.get_property('foo'), 2)
         self.assertEqual(goods.get_property('monty'), 'python')
@@ -87,7 +87,7 @@ class TestArrival(WmsTestCase):
                                       physobj_code='765',
                                       physobj_properties=dict(foo=5,
                                                               bar='monty'),
-                                      physobj_type=self.goods_type)
+                                      physobj_type=self.physobj_type)
 
         def assert_warnings_goods_deprecation(got_warnings):
             self.assert_warnings_deprecation(
@@ -126,46 +126,46 @@ class TestArrival(WmsTestCase):
     def test_arrival_done_obliviate(self):
         arrival = self.Arrival.create(location=self.incoming_loc,
                                       state='done',
-                                      goods_code='x34/7',
-                                      goods_properties=dict(foo=2,
-                                                            monty='python'),
-                                      goods_type=self.goods_type)
+                                      physobj_code='x34/7',
+                                      physobj_properties=dict(foo=2,
+                                                              monty='python'),
+                                      physobj_type=self.physobj_type)
         arrival.obliviate()
         self.assertEqual(self.Avatar.query().count(), 0)
         self.assertEqual(
-            self.PhysObj.query().filter_by(type=self.goods_type).count(), 0)
+            self.PhysObj.query().filter_by(type=self.physobj_type).count(), 0)
 
     def test_arrival_planned_execute_obliviate(self):
         arrival = self.Arrival.create(location=self.incoming_loc,
                                       state='planned',
                                       dt_execution=self.dt_test1,
-                                      goods_code='x34/7',
-                                      goods_properties=dict(foo=2,
-                                                            monty='python'),
-                                      goods_type=self.goods_type)
+                                      physobj_code='x34/7',
+                                      physobj_properties=dict(foo=2,
+                                                              monty='python'),
+                                      physobj_type=self.physobj_type)
         arrival.execute()
         arrival.obliviate()
         self.assertEqual(self.Avatar.query().count(), 0)
         self.assertEqual(
-            self.PhysObj.query().filter_by(type=self.goods_type).count(), 0)
+            self.PhysObj.query().filter_by(type=self.physobj_type).count(), 0)
 
     def test_repr(self):
         arrival = self.Arrival(location=self.incoming_loc,
                                state='done',
-                               goods_code='x34/7',
-                               goods_properties=dict(foo=2,
-                                                     monty='python'),
-                               goods_type=self.goods_type)
+                               physobj_code='x34/7',
+                               physobj_properties=dict(foo=2,
+                                                       monty='python'),
+                               physobj_type=self.physobj_type)
         repr(arrival)
         str(arrival)
 
     def test_not_a_container(self):
-        wrong_loc = self.PhysObj.insert(type=self.goods_type)
+        wrong_loc = self.PhysObj.insert(type=self.physobj_type)
         with self.assertRaises(OperationContainerExpected) as arc:
             self.Arrival.create(
                 location=wrong_loc,
                 state='done',
-                goods_type=self.goods_type)
+                physobj_type=self.physobj_type)
         exc = arc.exception
         str(exc)
         repr(exc)

--- a/anyblok_wms_base/core/operation/tests/test_assembly.py
+++ b/anyblok_wms_base/core/operation/tests/test_assembly.py
@@ -49,7 +49,7 @@ class TestAssembly(WmsTestCase):
             location = self.stock
         for gt, qty in spec:
             for _ in range(qty):
-                arrival = Arrival.create(goods_type=gt,
+                arrival = Arrival.create(physobj_type=gt,
                                          location=location,
                                          state=arrival_state,
                                          dt_execution=self.dt_test1)

--- a/anyblok_wms_base/core/operation/tests/test_assembly.py
+++ b/anyblok_wms_base/core/operation/tests/test_assembly.py
@@ -753,7 +753,7 @@ class TestAssembly(WmsTestCase):
                                forward_properties=['foo'],
                                properties=dict(batch=None),
                                quantity=1,
-                               local_goods_ids=[avatars[-1].obj.id])])
+                               local_physobj_ids=[avatars[-1].obj.id])])
         self.assertEqual(len(assembly.match), 1)
         self.assertEqual(set(assembly.match[0]),
                          set(av.id for av in avatars[:2]))

--- a/anyblok_wms_base/core/operation/tests/test_operation.py
+++ b/anyblok_wms_base/core/operation/tests/test_operation.py
@@ -25,20 +25,20 @@ class TestOperation(WmsTestCase):
         self.incoming_loc = self.insert_location('INCOMING')
         self.stock = self.insert_location('STOCK')
 
-        self.goods_type = PhysObj.Type.insert(label="My good type",
-                                              code='MyGT')
+        self.physobj_type = PhysObj.Type.insert(label="My good type",
+                                                code='MyGT')
 
     def test_execute_idempotency(self):
         op = self.Operation.Arrival.create(location=self.incoming_loc,
                                            state='planned',
                                            dt_execution=self.dt_test2,
-                                           goods_type=self.goods_type)
+                                           physobj_type=self.physobj_type)
         op.state = 'done'
         op.execute_planned = lambda: self.fail("Should not be called")
         op.execute()
 
     def test_history(self):
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                                 dt_execution=self.dt_test1,
                                                 location=self.incoming_loc,
                                                 state='planned')
@@ -51,12 +51,12 @@ class TestOperation(WmsTestCase):
         self.assert_singleton(arrival.followers, value=move)
 
     def test_len_inputs(self):
-        arrival = self.Operation.Arrival.insert(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.insert(physobj_type=self.physobj_type,
                                                 dt_execution=self.dt_test1,
                                                 location=self.incoming_loc,
                                                 state='planned')
         Avatar = self.PhysObj.Avatar
-        goods = [Avatar.insert(obj=self.PhysObj.insert(type=self.goods_type),
+        goods = [Avatar.insert(obj=self.PhysObj.insert(type=self.physobj_type),
                                location=self.incoming_loc,
                                dt_from=self.dt_test1,
                                state='future',
@@ -70,14 +70,14 @@ class TestOperation(WmsTestCase):
         self.assertEqual(arc.exception.kwargs.get('nb'), 2)
 
     def test_link_inputs(self):
-        arrival = self.Operation.Arrival.insert(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.insert(physobj_type=self.physobj_type,
                                                 dt_execution=self.dt_test1,
                                                 location=self.incoming_loc,
                                                 state='planned')
         Avatar = self.PhysObj.Avatar
         avatars = [
             Avatar.insert(
-                obj=self.PhysObj.insert(type=self.goods_type),
+                obj=self.PhysObj.insert(type=self.physobj_type),
                 location=self.incoming_loc,
                 dt_from=self.dt_test1,
                 dt_until=dt,
@@ -131,7 +131,7 @@ class TestOperation(WmsTestCase):
         orig_before_insert = Arrival.before_insert
         Arrival.before_insert = before_insert
         try:
-            arrival = Arrival.create(goods_type=self.goods_type,
+            arrival = Arrival.create(physobj_type=self.physobj_type,
                                      location=self.incoming_loc,
                                      dt_execution=self.dt_test1,
                                      state='planned')
@@ -142,7 +142,7 @@ class TestOperation(WmsTestCase):
         self.assertEqual(arrival.outcomes[0].location, other_loc)
 
     def test_cancel(self):
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                                 location=self.incoming_loc,
                                                 dt_execution=self.dt_test1,
                                                 state='planned')
@@ -156,7 +156,7 @@ class TestOperation(WmsTestCase):
 
     def test_cancel_done(self):
         """One can't cancel an operation that's already done."""
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                                 location=self.incoming_loc,
                                                 dt_execution=self.dt_test1,
                                                 state='done')
@@ -164,7 +164,7 @@ class TestOperation(WmsTestCase):
             arrival.cancel()
 
     def test_cancel_recursion(self):
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                                 location=self.incoming_loc,
                                                 dt_execution=self.dt_test1,
                                                 state='planned')
@@ -193,7 +193,7 @@ class TestOperation(WmsTestCase):
     def test_plan_revert_recurse_linear(self):
         workshop = self.PhysObj.insert(code="Workshop",
                                        type=self.stock.type)
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                                 location=self.incoming_loc,
                                                 dt_execution=self.dt_test1,
                                                 state='done')
@@ -235,7 +235,7 @@ class TestOperation(WmsTestCase):
         self.assertEqual(avatar.location, self.incoming_loc)
 
     def test_plan_revert_recurse_wrong_state(self):
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                                 location=self.incoming_loc,
                                                 dt_execution=self.dt_test1,
                                                 state='done')
@@ -249,7 +249,7 @@ class TestOperation(WmsTestCase):
             move.plan_revert()
 
     def test_plan_revert_recurse_irreversible(self):
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                                 location=self.incoming_loc,
                                                 state='done',
                                                 dt_execution=self.dt_test1)
@@ -272,7 +272,7 @@ class TestOperation(WmsTestCase):
         self.assertEqual(exc.kwargs.get('op'), departure)
 
     def test_obliviate_planned(self):
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                                 location=self.incoming_loc,
                                                 dt_execution=self.dt_test1,
                                                 state='planned')
@@ -284,7 +284,7 @@ class TestOperation(WmsTestCase):
     def test_obliviate_recurse_linear(self):
         workshop = self.PhysObj.insert(code="Workshop",
                                        type=self.stock.type)
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                                 location=self.incoming_loc,
                                                 dt_execution=self.dt_test1,
                                                 state='done')
@@ -314,13 +314,13 @@ class TestOperation(WmsTestCase):
 
     def test_planned_default_dt_execution_no_inputs(self):
         now = datetime.now(tz=self.dt_test1.tzinfo)
-        arr = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arr = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                             location=self.incoming_loc,
                                             state='planned')
         self.assertTrue(arr.dt_execution > now)
 
     def test_planned_default_dt_execution_inputs(self):
-        arr = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arr = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                             location=self.incoming_loc,
                                             dt_execution=self.dt_test1,
                                             state='planned')
@@ -329,7 +329,7 @@ class TestOperation(WmsTestCase):
         self.assertEqual(departure.dt_execution, self.dt_test1)
 
     def test_check_alterable(self):
-        arr = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arr = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                             location=self.incoming_loc,
                                             dt_execution=self.dt_test1,
                                             state='planned')
@@ -343,7 +343,7 @@ class TestOperation(WmsTestCase):
         self.assertEqual(exc.kwargs.get('state'), 'done')
 
     def test_alter_with_trailing_move_inapplicable(self):
-        arr = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arr = self.Operation.Arrival.create(physobj_type=self.physobj_type,
                                             location=self.incoming_loc,
                                             dt_execution=self.dt_test1,
                                             state='planned')

--- a/anyblok_wms_base/core/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/core/operation/tests/test_unpack.py
@@ -23,26 +23,26 @@ class TestUnpack(WmsTestCase):
         self.default_quantity_location = self.stock
 
     def create_packs(self, type_behaviours=None, properties=None):
-        self.packed_goods_type = self.PhysObj.Type.insert(
+        self.packed_physobj_type = self.PhysObj.Type.insert(
             label="Pack",
             code='PACK',
             behaviours=type_behaviours)
         self.arrival = self.Operation.Arrival.create(
-            goods_type=self.packed_goods_type,
+            physobj_type=self.packed_physobj_type,
             location=self.stock,
             dt_execution=self.dt_test1,
-            goods_properties=properties,
+            physobj_properties=properties,
             state='planned')
 
         self.packs = self.assert_singleton(self.arrival.outcomes)
 
-    def assert_goods_records(self, count, goods_type):
+    def assert_physobj_records(self, count, physobj_type):
         """Assert count of PhysObj with given type and return them.
 
         This is primarily meant for PhysObj produced by the Unpack
         """
         records = self.PhysObj.query().filter(
-            self.PhysObj.type == goods_type).all()
+            self.PhysObj.type == physobj_type).all()
         self.assertEqual(len(records), count)
         return records
 
@@ -70,7 +70,7 @@ class TestUnpack(WmsTestCase):
                                  input=self.packs)
         self.assert_singleton(unp.follows, value=self.arrival)
 
-        for unpacked_goods in self.assert_goods_records(3, unpacked_type):
+        for unpacked_goods in self.assert_physobj_records(3, unpacked_type):
             self.assertEqual(unpacked_goods.type, unpacked_type)
 
     def test_done_clone_one_not_clone(self):
@@ -102,11 +102,11 @@ class TestUnpack(WmsTestCase):
                                  input=self.packs)
         self.assert_singleton(unp.follows, value=self.arrival)
 
-        for goods in self.assert_goods_records(2, unpacked_clone_type):
+        for goods in self.assert_physobj_records(2, unpacked_clone_type):
             self.assertEqual(goods.properties,
                              self.packs.obj.properties)
 
-        for goods in self.assert_goods_records(3, unpacked_fwd_type):
+        for goods in self.assert_physobj_records(3, unpacked_fwd_type):
             self.assertNotEqual(goods.properties,
                                 self.packs.obj.properties)
             self.assertIsNone(goods.get_property('other'))
@@ -131,7 +131,7 @@ class TestUnpack(WmsTestCase):
                                  input=self.packs)
         self.assert_singleton(unp.follows, value=self.arrival)
 
-        for goods in self.assert_goods_records(3, unpacked_type):
+        for goods in self.assert_physobj_records(3, unpacked_type):
             self.assertEqual(goods.properties,
                              self.packs.obj.properties)
 
@@ -165,7 +165,7 @@ class TestUnpack(WmsTestCase):
                                  input=self.packs)
         self.assert_singleton(unp.follows, value=self.arrival)
 
-        for unpacked_goods in self.assert_goods_records(2, unpacked_type):
+        for unpacked_goods in self.assert_physobj_records(2, unpacked_type):
             self.assertEqual(unpacked_goods.type, unpacked_type)
             self.assertEqual(unpacked_goods.get_property('direct'), 'hop')
             self.assertEqual(unpacked_goods.get_property('foo'), 3)
@@ -213,7 +213,7 @@ class TestUnpack(WmsTestCase):
                                  input=self.packs)
         self.assert_singleton(unp.follows, value=self.arrival)
 
-        unpacked_goods = self.assert_goods_records(2, unpacked_type)
+        unpacked_goods = self.assert_physobj_records(2, unpacked_type)
         self.assertEqual(
             set((g, g.get_property('grade')) for g in unpacked_goods),
             set(((outcome1, 'best'), (outcome2, 'regular'))))
@@ -286,7 +286,7 @@ class TestUnpack(WmsTestCase):
         exc_kwargs = arc.exception.kwargs
         self.assertEqual(list(exc_kwargs.get('inputs')), [self.packs])
         self.assertEqual(exc_kwargs.get('req_props'), ['foo'])
-        self.assertEqual(exc_kwargs.get('type'), self.packed_goods_type)
+        self.assertEqual(exc_kwargs.get('type'), self.packed_physobj_type)
         # we also have an 'operation' kwarg, because that exc is raised
         # after actual instantiation, but we can't test it because
         # we don't have a create() returned value to compare
@@ -319,7 +319,7 @@ class TestUnpack(WmsTestCase):
                                  input=self.packs)
         self.assert_singleton(unp.follows, value=self.arrival)
 
-        for unpacked_goods in self.assert_goods_records(3, unpacked_type):
+        for unpacked_goods in self.assert_physobj_records(3, unpacked_type):
             self.assertEqual(unpacked_goods.type, unpacked_type)
             self.assertEqual(unpacked_goods.properties, None)
 
@@ -350,7 +350,7 @@ class TestUnpack(WmsTestCase):
         self.assert_singleton(unp.follows, value=self.arrival)
 
         self.assertEqual(len(unp.outcomes), 2)
-        for unpacked_goods in self.assert_goods_records(2, unpacked_type):
+        for unpacked_goods in self.assert_physobj_records(2, unpacked_type):
             self.assertEqual(unpacked_goods.type, unpacked_type)
             self.assertEqual(unpacked_goods.get_property('foo'), 3)
             self.assertEqual(unpacked_goods.get_property('baz'), 'second hand')
@@ -360,7 +360,7 @@ class TestUnpack(WmsTestCase):
             self.assertEqual(avatar.outcome_of, unp)
 
         self.assert_quantity(0,
-                             goods_type=self.packed_goods_type,
+                             physobj_type=self.packed_physobj_type,
                              at_datetime=self.dt_test2,
                              additional_states=['future'])
 
@@ -372,12 +372,12 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(self.packs.state, 'past')
 
         self.assert_quantity(0,
-                             goods_type=self.packed_goods_type,
+                             physobj_type=self.packed_physobj_type,
                              at_datetime=self.dt_test2,
                              additional_states=['future']),
         self.assertEqual(
             self.Avatar.query().join(self.Avatar.obj).filter(
-                self.PhysObj.type == self.packed_goods_type,
+                self.PhysObj.type == self.packed_physobj_type,
                 self.Avatar.state == 'future').count(),
             0)
 
@@ -394,7 +394,7 @@ class TestUnpack(WmsTestCase):
         str(arc.exception)
         repr(arc.exception)
         exc_kwargs = arc.exception.kwargs
-        self.assertEqual(exc_kwargs.get('type'), self.packed_goods_type)
+        self.assertEqual(exc_kwargs.get('type'), self.packed_physobj_type)
         self.assertEqual(list(exc_kwargs.get('inputs')), [self.packs])
         self.assertEqual(exc_kwargs.get('behaviour'), dict(outcomes=[]))
         self.assertEqual(exc_kwargs.get('specific'), ())
@@ -415,7 +415,7 @@ class TestUnpack(WmsTestCase):
         str(arc.exception)
         repr(arc.exception)
         exc_kwargs = arc.exception.kwargs
-        self.assertEqual(exc_kwargs.get('type'), self.packed_goods_type)
+        self.assertEqual(exc_kwargs.get('type'), self.packed_physobj_type)
         self.assertEqual(list(exc_kwargs.get('inputs')), [self.packs])
 
     def test_repr(self):
@@ -450,7 +450,7 @@ class TestUnpack(WmsTestCase):
         unp = self.Unpack.create(state='planned', input=self.packs,
                                  dt_execution=self.dt_test2)
 
-        del self.packed_goods_type.behaviours['unpack']
+        del self.packed_physobj_type.behaviours['unpack']
         self.assertEqual(unp.reverse_assembly_name(), 'pack')
 
     def test_revert_default_assembly_final(self):
@@ -479,10 +479,10 @@ class TestUnpack(WmsTestCase):
         assembly, _ = unp.plan_revert()
         assembly.execute()
 
-        self.assert_quantity(0, location=None, goods_type=unpacked_type)
+        self.assert_quantity(0, location=None, physobj_type=unpacked_type)
         self.assert_quantity(1,
                              location=None,
-                             goods_type=self.packed_goods_type)
+                             physobj_type=self.packed_physobj_type)
 
     def test_revert_default_assembly_not_final(self):
         unpacked_type = self.PhysObj.Type.insert(code="GT")
@@ -522,9 +522,10 @@ class TestUnpack(WmsTestCase):
         move_back.execute()
         assembly.execute()
 
-        self.assert_quantity(0, location=None, goods_type=unpacked_type)
+        self.assert_quantity(0, location=None, physobj_type=unpacked_type)
         self.assert_quantity(1,
-                             location=None, goods_type=self.packed_goods_type)
+                             location=None,
+                             physobj_type=self.packed_physobj_type)
 
     def test_revert_specified_assembly(self):
         unpacked_type = self.PhysObj.Type.insert(label="Unpacked", code='PCK')
@@ -582,7 +583,7 @@ class TestUnpack(WmsTestCase):
             PhysObj.query().filter(PhysObj.type == unpacked_type).count(),
             0)
         self.assert_quantity(1,
-                             goods_type=self.packed_goods_type,
+                             physobj_type=self.packed_physobj_type,
                              additional_states=['future'],
                              at_datetime=self.dt_test2)
 
@@ -604,7 +605,7 @@ class TestUnpack(WmsTestCase):
         for i in range(2):
             outcomes.update(self.Operation.Arrival.create(
                 state='planned',
-                goods_type=unpacked_type,
+                physobj_type=unpacked_type,
                 dt_execution=self.dt_test1,
                 location=location).outcomes)
 
@@ -634,7 +635,7 @@ class TestUnpack(WmsTestCase):
         for i in range(2):
             outcomes.update(self.Operation.Arrival.create(
                 state='planned',
-                goods_type=unpacked_type,
+                physobj_type=unpacked_type,
                 dt_execution=self.dt_test1,
                 location=location).outcomes)
 
@@ -670,8 +671,8 @@ class TestUnpack(WmsTestCase):
             outcomes.extend(
                 self.Operation.Arrival.create(
                     state='planned',
-                    goods_type=unpacked_type,
-                    goods_properties=dict(foo=7+i),
+                    physobj_type=unpacked_type,
+                    physobj_properties=dict(foo=7+i),
                     dt_execution=self.dt_test1,
                     location=location).outcomes)
 
@@ -705,7 +706,7 @@ class TestUnpack(WmsTestCase):
         for i in range(2):
             outcomes.update(self.Operation.Arrival.create(
                 state='planned',
-                goods_type=unpacked_type,
+                physobj_type=unpacked_type,
                 dt_execution=self.dt_test1,
                 location=location).outcomes)
 

--- a/anyblok_wms_base/core/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/core/operation/tests/test_unpack.py
@@ -172,10 +172,10 @@ class TestUnpack(WmsTestCase):
             self.assertEqual(unpacked_goods.get_property('baz'), 'second hand')
 
     def test_done_non_uniform_local_id(self):
-        """Unpack with local_goods_ids in pack properties.
+        """Unpack with local_physobj_ids in pack properties.
 
         The unpacked PhysObj are directly picked by the specified values of
-        ``local_goods_ids``.
+        ``local_physobj_ids``.
 
         Properties after unpack are still forwarded according to configuration
         on the packs' PhysObj Type and on the packs' properties.
@@ -196,13 +196,13 @@ class TestUnpack(WmsTestCase):
                             contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=1,
-                                     local_goods_ids=[outcome1.id],
+                                     local_physobj_ids=[outcome1.id],
                                      properties=dict(direct='ignored'),
                                      forward_properties=['bar']
                                      ),
                                 dict(type=unpacked_type.code,
                                      quantity=1,
-                                     local_goods_ids=[outcome2.id],
+                                     local_physobj_ids=[outcome2.id],
                                      properties=dict(direct='ignored'),
                                      forward_properties=['bar']
                                      )
@@ -224,7 +224,7 @@ class TestUnpack(WmsTestCase):
             self.assertEqual(unpacked.get_property('bar'), 'yes')
 
     def test_done_non_uniform_local_id_wrong_qty(self):
-        """Unpack with local_goods_ids in pack properties, wrong quantity
+        """Unpack with local_physobj_ids in pack properties, wrong quantity
         """
         unpacked_type = self.PhysObj.Type.insert(code='Unpacked')
         outcome1 = self.PhysObj.insert(type=unpacked_type)
@@ -239,7 +239,7 @@ class TestUnpack(WmsTestCase):
                             contents=[
                                 dict(type=unpacked_type.code,
                                      quantity=2,
-                                     local_goods_ids=[outcome1.id],
+                                     local_physobj_ids=[outcome1.id],
                                      ),
                             ]))
         self.packs.update(state='present')
@@ -254,7 +254,7 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(exckw.get('spec'),
                          dict(type=unpacked_type.code,
                               quantity=2,
-                              local_goods_ids=[outcome1.id],
+                              local_physobj_ids=[outcome1.id],
                               forward_properties=['foo'],
                               required_properties=['foo']))
 

--- a/anyblok_wms_base/core/operation/unpack.py
+++ b/anyblok_wms_base/core/operation/unpack.py
@@ -83,7 +83,7 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
                        responsibility of this method.
         :param spec: specification for these PhysObj, should be used minimally
                      in subclasses, typically for quantity related adjustments.
-                     Also, if the special ``local_goods_ids`` is provided,
+                     Also, if the special ``local_physobj_ids`` is provided,
                      this method should attempt to reuse the PhysObj record
                      with that ``id`` (interplay with quantity might depend
                      on the implementation).
@@ -93,14 +93,14 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
                  total quantity.
         """
         PhysObj = self.registry.Wms.PhysObj
-        existing_ids = spec.get('local_goods_ids')
+        existing_ids = spec.get('local_physobj_ids')
         target_qty = spec['quantity']
         if existing_ids is not None:
             if len(existing_ids) != target_qty:
                 raise OperationInputsError(
                     self,
                     "final outcome specification {spec!r} has "
-                    "'local_goods_ids' parameter, but they don't provide "
+                    "'local_physobj_ids' parameter, but they don't provide "
                     "the wished total quantity {target_qty} "
                     "Detailed input: {inputs[0]!r}",
                     spec=spec, target_qty=target_qty)
@@ -258,7 +258,7 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
             the lowest precedence, meaning that they will
             be overridden by properties forwarded from ``self.input``.
 
-            Also, if spec has the ``local_goods_id`` key, ``properties`` is
+            Also, if spec has the ``local_physobj_id`` key, ``properties`` is
             ignored. The rationale for this is that normally, there are no
             present or future Avatar for these PhysObj, and therefore the
             Properties of outcome should not have diverged from the contents
@@ -281,7 +281,7 @@ class Unpack(Mixin.WmsSingleInputOperation, Operation):
         """
         props_upd = {}
         direct_props = spec.get('properties')
-        if direct_props is not None and 'local_goods_ids' not in spec:
+        if direct_props is not None and 'local_physobj_ids' not in spec:
             props_upd.update(direct_props)
         packs = self.input.obj
         fwd_props = spec.get('forward_properties', ())

--- a/anyblok_wms_base/core/physobj/tests/test_containers.py
+++ b/anyblok_wms_base/core/physobj/tests/test_containers.py
@@ -24,7 +24,7 @@ class TestContainers(WmsTestCase):
 
         # just a placeholder for subsequent Avatar insertions
         self.arrival = self.Operation.Arrival.insert(
-            goods_type=self.physobj_type,
+            physobj_type=self.physobj_type,
             location=self.stock,
             dt_execution=self.dt_test1,
             state='done')

--- a/anyblok_wms_base/core/tests/__init__.py
+++ b/anyblok_wms_base/core/tests/__init__.py
@@ -15,13 +15,13 @@ class TestCore(BlokTestCase):
 
     def test_minimal(self):
         Wms = self.registry.Wms
-        goods_type = Wms.PhysObj.Type.insert(label="My good type",
-                                             code='MyGT')
-        self.assertEqual(goods_type.label, "My good type")
+        physobj_type = Wms.PhysObj.Type.insert(label="My good type",
+                                               code='MyGT')
+        self.assertEqual(physobj_type.label, "My good type")
 
         location_type = Wms.PhysObj.Type.insert(code="LOC")
         loc = Wms.PhysObj.insert(code="Root", type=location_type)
-        arrival = Wms.Operation.Arrival.insert(goods_type=goods_type,
+        arrival = Wms.Operation.Arrival.insert(physobj_type=physobj_type,
                                                location=loc,
                                                dt_execution=datetime.now(),
                                                state='done')

--- a/anyblok_wms_base/core/tests/test_quantity.py
+++ b/anyblok_wms_base/core/tests/test_quantity.py
@@ -25,7 +25,7 @@ class TestQuantity(WmsTestCase):
 
         # just a placeholder for subsequent Avatar insertions
         self.arrival = self.Operation.Arrival.insert(
-            goods_type=self.physobj_type,
+            physobj_type=self.physobj_type,
             location=self.stock,
             dt_execution=self.dt_test1,
             state='done')
@@ -157,8 +157,8 @@ class TestQuantity(WmsTestCase):
         self.insert_goods(2, 'past', self.dt_test1, until=self.dt_test2)
 
         self.assert_quantity(3)
-        self.assert_quantity(3, goods_type=self.physobj_type)
-        self.assert_quantity(0, goods_type=self.PhysObj.Type.insert(
+        self.assert_quantity(3, physobj_type=self.physobj_type)
+        self.assert_quantity(0, physobj_type=self.PhysObj.Type.insert(
             code='other'))
 
         self.assert_quantity(7, additional_states=['future'],
@@ -180,10 +180,10 @@ class TestQuantity(WmsTestCase):
         self.insert_goods(2, 'present', self.dt_test1, location=sub)
         self.insert_goods(1, 'present', self.dt_test1, location=self.stock)
 
-        self.assert_quantity(1, goods_type=self.physobj_type,
+        self.assert_quantity(1, physobj_type=self.physobj_type,
                              location=self.stock,
                              location_recurse=False)
-        self.assert_quantity(2, goods_type=self.physobj_type,
+        self.assert_quantity(2, physobj_type=self.physobj_type,
                              location=sub,
                              location_recurse=False)
 

--- a/anyblok_wms_base/core/tests/test_testing.py
+++ b/anyblok_wms_base/core/tests/test_testing.py
@@ -30,5 +30,20 @@ class TestWmsTestCase(WmsTestCaseWithPhysObj):
             self.Avatar.query().filter_by(obj=loc).all())
         self.assertEqual(av.dt_from, self.dt_test1)
 
+    def test_assert_quantity(self):
+        self.assert_quantity(0, physobj_type=self.physobj_type)
+        self.assert_quantity(1, physobj_type=self.physobj_type,
+                             additional_states=['future'],
+                             at_datetime=self.dt_test3)
+
+    def test_assert_quantity_default_type(self):
+        self.assert_quantity(1, additional_states=['future'],
+                             at_datetime=self.dt_test3)
+
+    def test_assert_quantity_api_compat(self):
+        self.assert_quantity(1, goods_type=self.physobj_type,
+                             additional_states=['future'],
+                             at_datetime=self.dt_test3)
+
 
 del WmsTestCaseWithPhysObj

--- a/anyblok_wms_base/quantity/operation/arrival.py
+++ b/anyblok_wms_base/quantity/operation/arrival.py
@@ -33,23 +33,23 @@ class Arrival:
                             name='positive_qty'),)
 
     def specific_repr(self):
-        return ("goods_type={self.goods_type!r}, "
+        return ("physobj_type={self.physobj_type!r}, "
                 "location={self.location!r}, "
                 "quantity={self.quantity}").format(self=self)
 
     def after_insert(self):
         # TODO reduce duplication
         PhysObj = self.registry.Wms.PhysObj
-        self_props = self.goods_properties
+        self_props = self.physobj_properties
         if self_props is None:
             props = None
         else:
             props = PhysObj.Properties.create(**self_props)
 
-        goods = PhysObj.insert(type=self.goods_type,
+        goods = PhysObj.insert(type=self.physobj_type,
                                properties=props,
                                quantity=self.quantity,
-                               code=self.goods_code)
+                               code=self.physobj_code)
         PhysObj.Avatar.insert(
             obj=goods,
             location=self.location,

--- a/anyblok_wms_base/quantity/operation/tests/test_aggregate.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_aggregate.py
@@ -29,7 +29,7 @@ class TestAggregate(WmsTestCase):
 
         # The arrival fields don't matter, we'll insert goods directly
         self.arrivals = [
-            Operation.Arrival.create(goods_type=self.physobj_type,
+            Operation.Arrival.create(physobj_type=self.physobj_type,
                                      location=self.loc,
                                      state='planned',
                                      dt_execution=self.dt_test1,
@@ -136,7 +136,7 @@ class TestAggregate(WmsTestCase):
         for record in self.avatars:
             record.state = 'present'
         Operation = self.registry.Wms.Operation
-        other_reason = Operation.Arrival.insert(goods_type=self.physobj_type,
+        other_reason = Operation.Arrival.insert(physobj_type=self.physobj_type,
                                                 location=self.loc,
                                                 state='done',
                                                 dt_execution=self.dt_test1,
@@ -190,7 +190,7 @@ class TestAggregate(WmsTestCase):
         with self.assertRaises(OperationMissingInputsError):
             self.plan_aggregate()
 
-    def test_create_done_ensure_goods_present(self):
+    def test_create_done_ensure_physobj_present(self):
         # nowadays, this just tests the base Operation class
         with self.assertRaises(OperationInputWrongState) as arc:
             self.Agg.create(inputs=self.avatars, state='done',
@@ -208,7 +208,7 @@ class TestAggregate(WmsTestCase):
         self.assertEqual(exc_kwargs.get('inputs'), self.avatars)
         self.assertEqual(exc_kwargs.get('record'), self.avatars[1])
 
-    def test_execute_ensure_goods_present(self):
+    def test_execute_ensure_physobj_present(self):
         # nowadays, this just tests the base Operation class
         agg = self.plan_aggregate()
         with self.assertRaises(OperationInputWrongState) as arc:

--- a/anyblok_wms_base/quantity/operation/tests/test_arrival.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_arrival.py
@@ -14,8 +14,8 @@ class TestArrival(WmsTestCase):
     def setUp(self):
         super(TestArrival, self).setUp()
         Wms = self.registry.Wms
-        self.goods_type = Wms.PhysObj.Type.insert(label="My good type",
-                                                  code='MyGT')
+        self.physobj_type = Wms.PhysObj.Type.insert(label="My good type",
+                                                    code='MyGT')
         self.incoming_loc = self.insert_location('Incoming')
         self.stock = self.insert_location('Stock')
         self.Arrival = Wms.Operation.Arrival
@@ -27,17 +27,17 @@ class TestArrival(WmsTestCase):
                                       quantity=3,
                                       state='planned',
                                       dt_execution=self.dt_test1,
-                                      goods_code='765',
-                                      goods_properties=dict(foo=5,
-                                                            bar='monty'),
-                                      goods_type=self.goods_type)
+                                      physobj_code='765',
+                                      physobj_properties=dict(foo=5,
+                                                              bar='monty'),
+                                      physobj_type=self.physobj_type)
         self.assertEqual(len(arrival.follows), 0)
         avatar = self.assert_singleton(arrival.outcomes)
         goods = avatar.obj
         self.assertEqual(avatar.state, 'future')
         self.assertEqual(avatar.location, self.incoming_loc)
         self.assertEqual(goods.quantity, 3)
-        self.assertEqual(goods.type, self.goods_type)
+        self.assertEqual(goods.type, self.physobj_type)
         self.assertEqual(goods.code, '765')
         self.assertEqual(goods.get_property('foo'), 5)
         self.assertEqual(goods.get_property('bar'), 'monty')
@@ -57,17 +57,17 @@ class TestArrival(WmsTestCase):
         arrival = self.Arrival.create(location=self.incoming_loc,
                                       quantity=3,
                                       state='done',
-                                      goods_code='x34/7',
-                                      goods_properties=dict(foo=2,
-                                                            monty='python'),
-                                      goods_type=self.goods_type)
+                                      physobj_code='x34/7',
+                                      physobj_properties=dict(foo=2,
+                                                              monty='python'),
+                                      physobj_type=self.physobj_type)
         self.assertEqual(len(arrival.follows), 0)
         avatar = self.assert_singleton(arrival.outcomes)
         self.assertEqual(avatar.state, 'present')
         self.assertEqual(avatar.location, self.incoming_loc)
         goods = avatar.obj
         self.assertEqual(goods.quantity, 3)
-        self.assertEqual(goods.type, self.goods_type)
+        self.assertEqual(goods.type, self.physobj_type)
         self.assertEqual(goods.code, 'x34/7')
         self.assertEqual(goods.get_property('foo'), 2)
         self.assertEqual(goods.get_property('monty'), 'python')
@@ -76,14 +76,14 @@ class TestArrival(WmsTestCase):
         arrival = self.Arrival.create(location=self.incoming_loc,
                                       quantity=3,
                                       state='done',
-                                      goods_code='x34/7',
-                                      goods_properties=dict(foo=2,
-                                                            monty='python'),
-                                      goods_type=self.goods_type)
+                                      physobj_code='x34/7',
+                                      physobj_properties=dict(foo=2,
+                                                              monty='python'),
+                                      physobj_type=self.physobj_type)
         arrival.obliviate()
         self.assertEqual(self.Avatar.query().count(), 0)
         self.assertEqual(
-            self.PhysObj.query().filter_by(type=self.goods_type).count(),
+            self.PhysObj.query().filter_by(type=self.physobj_type).count(),
             0)
 
     def test_arrival_planned_execute_obliviate(self):
@@ -91,24 +91,24 @@ class TestArrival(WmsTestCase):
                                       quantity=3,
                                       state='planned',
                                       dt_execution=self.dt_test1,
-                                      goods_code='x34/7',
-                                      goods_properties=dict(foo=2,
-                                                            monty='python'),
-                                      goods_type=self.goods_type)
+                                      physobj_code='x34/7',
+                                      physobj_properties=dict(foo=2,
+                                                              monty='python'),
+                                      physobj_type=self.physobj_type)
         arrival.execute()
         arrival.obliviate()
         self.assertEqual(self.Avatar.query().count(), 0)
         self.assertEqual(
-            self.PhysObj.query().filter_by(type=self.goods_type).count(),
+            self.PhysObj.query().filter_by(type=self.physobj_type).count(),
             0)
 
     def test_repr(self):
         arrival = self.Arrival(location=self.incoming_loc,
                                quantity=3,
                                state='done',
-                               goods_code='x34/7',
-                               goods_properties=dict(foo=2,
-                                                     monty='python'),
-                               goods_type=self.goods_type)
+                               physobj_code='x34/7',
+                               physobj_properties=dict(foo=2,
+                                                       monty='python'),
+                               physobj_type=self.physobj_type)
         repr(arrival)
         str(arrival)

--- a/anyblok_wms_base/quantity/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_unpack.py
@@ -23,15 +23,15 @@ class TestUnpack(WmsTestCase):
         self.default_quantity_location = self.stock
 
     def create_packs(self, type_behaviours=None, properties=None, quantity=5):
-        self.packed_goods_type = self.PhysObj.Type.insert(
+        self.packed_physobj_type = self.PhysObj.Type.insert(
             label="Pack",
             code='PCK',
             behaviours=type_behaviours)
         self.arrival = self.Operation.Arrival.create(
-            goods_type=self.packed_goods_type,
+            physobj_type=self.packed_physobj_type,
             location=self.stock,
             dt_execution=self.dt_test1,
-            goods_properties=properties,
+            physobj_properties=properties,
             state='planned',
             quantity=quantity)
 
@@ -94,21 +94,21 @@ class TestUnpack(WmsTestCase):
                                  input=self.packs)
         self.assert_singleton(unp.follows, value=self.arrival)
 
-        unpacked_goods_cloned_props = self.single_result(
+        unpacked_physobj_cloned_props = self.single_result(
             self.PhysObj.query().filter(
                 self.PhysObj.type == unpacked_clone_type))
-        self.assertEqual(unpacked_goods_cloned_props.quantity, 10)
-        self.assertEqual(unpacked_goods_cloned_props.properties,
+        self.assertEqual(unpacked_physobj_cloned_props.quantity, 10)
+        self.assertEqual(unpacked_physobj_cloned_props.properties,
                          self.packs.obj.properties)
 
-        unpacked_goods_fwd_props = self.single_result(
+        unpacked_physobj_fwd_props = self.single_result(
             self.PhysObj.query().filter(
                 self.PhysObj.type == unpacked_fwd_type))
-        self.assertEqual(unpacked_goods_fwd_props.quantity, 15)
-        self.assertNotEqual(unpacked_goods_fwd_props.properties,
+        self.assertEqual(unpacked_physobj_fwd_props.quantity, 15)
+        self.assertNotEqual(unpacked_physobj_fwd_props.properties,
                             self.packs.obj.properties)
-        self.assertIsNone(unpacked_goods_fwd_props.get_property('other'))
-        self.assertEqual(unpacked_goods_fwd_props.get_property('foo'), 3)
+        self.assertIsNone(unpacked_physobj_fwd_props.get_property('other'))
+        self.assertEqual(unpacked_physobj_fwd_props.get_property('foo'), 3)
 
     def test_whole_done_one_unpacked_unform(self):
         unpacked_type = self.PhysObj.Type.insert(code='Unpacked')
@@ -284,7 +284,7 @@ class TestUnpack(WmsTestCase):
         exc_kwargs = arc.exception.kwargs
         self.assertEqual(list(exc_kwargs.get('inputs')), [self.packs])
         self.assertEqual(exc_kwargs.get('req_props'), ['foo'])
-        self.assertEqual(exc_kwargs.get('type'), self.packed_goods_type)
+        self.assertEqual(exc_kwargs.get('type'), self.packed_physobj_type)
         # we also have an 'operation' kwarg, because that exc is raised
         # after actual instantiation, but we can't test it because
         # we don't have a create() returned value to compare
@@ -364,7 +364,7 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(avatar.outcome_of, unp)
 
         self.assert_quantity(0,
-                             goods_type=self.packed_goods_type,
+                             physobj_type=self.packed_physobj_type,
                              at_datetime=self.dt_test2,
                              additional_states=['future'])
 
@@ -375,12 +375,12 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(self.packs.state, 'past')
 
         self.assert_quantity(0,
-                             goods_type=self.packed_goods_type,
+                             physobj_type=self.packed_physobj_type,
                              at_datetime=self.dt_test2,
                              additional_states=['future'])
         self.assertEqual(
             self.Avatar.query().join(self.Avatar.obj).filter(
-                self.PhysObj.type == self.packed_goods_type,
+                self.PhysObj.type == self.packed_physobj_type,
                 self.Avatar.state == 'future').count(),
             0)
 
@@ -419,7 +419,7 @@ class TestUnpack(WmsTestCase):
         self.assertEqual(avatar.state, 'future')
 
         self.assert_quantity(1,
-                             goods_type=self.packed_goods_type,
+                             physobj_type=self.packed_physobj_type,
                              additional_states=['future'],
                              at_datetime=self.dt_test2)
 
@@ -429,10 +429,10 @@ class TestUnpack(WmsTestCase):
         PhysObj, Avatar = self.PhysObj, self.Avatar
 
         # not unpacked
-        packs_goods_query = PhysObj.query().filter(
-            PhysObj.type == self.packed_goods_type)
+        packs_physobj_query = PhysObj.query().filter(
+            PhysObj.type == self.packed_physobj_type)
         still_packed = self.single_result(
-            packs_goods_query.join(Avatar.obj).filter(
+            packs_physobj_query.join(Avatar.obj).filter(
                 Avatar.state == 'present'))
         self.assertEqual(still_packed.quantity, 1)
 
@@ -470,7 +470,7 @@ class TestUnpack(WmsTestCase):
             PhysObj.query().filter(PhysObj.type == unpacked_type).count(),
             0)
         self.assert_quantity(5,
-                             goods_type=self.packed_goods_type,
+                             physobj_type=self.packed_physobj_type,
                              additional_states=['future'],
                              at_datetime=self.dt_test2)
 
@@ -488,7 +488,7 @@ class TestUnpack(WmsTestCase):
         str(arc.exception)
         repr(arc.exception)
         exc_kwargs = arc.exception.kwargs
-        self.assertEqual(exc_kwargs.get('type'), self.packed_goods_type)
+        self.assertEqual(exc_kwargs.get('type'), self.packed_physobj_type)
         self.assertEqual(list(exc_kwargs.get('inputs')), [self.packs])
         self.assertEqual(exc_kwargs.get('behaviour'), dict(outcomes=[]))
         self.assertEqual(exc_kwargs.get('specific'), ())
@@ -510,7 +510,7 @@ class TestUnpack(WmsTestCase):
         str(arc.exception)
         repr(arc.exception)
         exc_kwargs = arc.exception.kwargs
-        self.assertEqual(exc_kwargs.get('type'), self.packed_goods_type)
+        self.assertEqual(exc_kwargs.get('type'), self.packed_physobj_type)
         self.assertEqual(list(exc_kwargs.get('inputs')), [self.packs])
 
     def test_repr(self):

--- a/anyblok_wms_base/quantity/tests/test_location.py
+++ b/anyblok_wms_base/quantity/tests/test_location.py
@@ -21,7 +21,7 @@ class TestLocation(WmsTestCase):
                                                      code='MyGT')
         self.stock = self.insert_location('STK')
         self.arrival = self.Operation.Arrival.insert(
-            goods_type=self.physobj_type,
+            physobj_type=self.physobj_type,
             location=self.stock,
             dt_execution=self.dt_test1,
             state='done',

--- a/anyblok_wms_base/quantity/tests/test_physobj.py
+++ b/anyblok_wms_base/quantity/tests/test_physobj.py
@@ -23,17 +23,18 @@ class TestPhysObj(WmsTestCase):
 
         self.PhysObj = Wms.PhysObj
         self.Avatar = Wms.PhysObj.Avatar
-        self.goods_type = self.PhysObj.Type.insert(label="My goods", code="MG")
+        self.physobj_type = self.PhysObj.Type.insert(label="My goods",
+                                                     code="MG")
         self.stock = self.insert_location('Stock')
         self.arrival = Wms.Operation.Arrival.insert(
-            goods_type=self.goods_type,
+            physobj_type=self.physobj_type,
             location=self.stock,
             dt_execution=self.dt_test1,
             state='done',
             quantity=1)
 
     def test_str(self):
-        gt = self.goods_type
+        gt = self.physobj_type
         goods = self.PhysObj.insert(type=gt, quantity=D('2.5'))
         self.assertEqual(repr(goods),
                          "Wms.PhysObj(id=%d, type="

--- a/anyblok_wms_base/reservation/tests/test_request.py
+++ b/anyblok_wms_base/reservation/tests/test_request.py
@@ -25,7 +25,7 @@ class RequestItemTestCase(WmsTestCase):
 
         # just so that we can insert avatars
         self.arrival = Wms.Operation.Arrival.insert(
-            goods_type=gt1,
+            physobj_type=gt1,
             state='planned',
             dt_execution=self.dt_test1,
             location=self.loc)

--- a/anyblok_wms_base/reservation/tests/test_reservation.py
+++ b/anyblok_wms_base/reservation/tests/test_reservation.py
@@ -24,7 +24,7 @@ class ReservationTestCase(WmsTestCase):
         self.incoming_loc = self.insert_location('INCOMING')
         self.stock = self.insert_location('STOCK')
 
-        arrival = self.Operation.Arrival.create(goods_type=self.goods_type,
+        arrival = self.Operation.Arrival.create(physobj_type=self.goods_type,
                                                 location=self.incoming_loc,
                                                 state='planned',
                                                 dt_execution=self.dt_test1)

--- a/anyblok_wms_base/testing.py
+++ b/anyblok_wms_base/testing.py
@@ -72,15 +72,20 @@ class WmsTestCase(BlokTestCase):
                 self.assertEqual(elt, value)
             return elt
 
-    def assert_quantity(self, quantity, location=_missing, goods_type=_missing,
+    def assert_quantity(self, quantity, location=_missing,
+                        goods_type=_missing, physobj_type=_missing,
                         **kwargs):
         if location is _missing:
             location = self.default_quantity_location
-        if goods_type is _missing:
-            goods_type = self.physobj_type
+        if physobj_type is _missing:
+            if goods_type is _missing:
+                # not worth a DeprecationWarning, I say
+                physobj_type = self.physobj_type
+            else:
+                physobj_type = goods_type
 
         self.assertEqual(self.Wms.quantity(location=location,
-                                           goods_type=goods_type,
+                                           goods_type=physobj_type,
                                            **kwargs), quantity)
 
     def assert_warnings_deprecation(self, got_warnings, *message_items):
@@ -167,7 +172,7 @@ class WmsTestCase(BlokTestCase):
                 dt_from=dt_from,
                 dt_until=None,
                 outcome_of=cls.Operation.Apparition.insert(
-                    goods_type=location_type,
+                    physobj_type=location_type,
                     quantity=1,
                     location=parent,
                     dt_execution=dt_from,
@@ -186,7 +191,7 @@ class WmsTestCaseWithPhysObj(SharedDataTestCase, WmsTestCase):
        actually, for now, equal to ``avatar``, but will be corrected or
        removed in a subsequent refactor (this is a leftover of the refactor
        that introduced avatars).
-    * ``goods_type``
+    * ``physobj_type``
     * ``arrival``: the reason for :attr:`avatar`
     * ``incoming_loc``: where that initial Avatar dwells
 
@@ -212,7 +217,7 @@ class WmsTestCaseWithPhysObj(SharedDataTestCase, WmsTestCase):
         cls.incoming_loc = cls.cls_insert_location('INCOMING')
         cls.stock = cls.cls_insert_location('STOCK')
 
-        cls.arrival = Operation.Arrival.create(goods_type=cls.physobj_type,
+        cls.arrival = Operation.Arrival.create(physobj_type=cls.physobj_type,
                                                location=cls.incoming_loc,
                                                state='planned',
                                                dt_execution=cls.dt_test1,


### PR DESCRIPTION
In the big refactor for 0.8, only the `goods` fields of Avatar and Reservation had been renamed for consistency with the Model name (`PhysObj`).

Now it's the turn of the `goods_*` fields of Operations. Only Arrival and Apparition are affected.

Unpack and Assembly also use a `local_goods_id` key in the `contents` Property. We rename it as well.
