### PR TITLE
Maintaining consistency of Avatar and Operations date/times

### DIFF
--- a/anyblok_wms_base/core/operation/base.py
+++ b/anyblok_wms_base/core/operation/base.py
@@ -763,9 +763,9 @@ class Operation:
         not supposed to call this method: they should use :meth:`obliviate`,
         which takes care of the necessary recursivity and the final deletion.
         """
+        self.delete_outcomes()
         self.reset_inputs_original_values(state='present')
         self.registry.flush()
-        self.delete_outcomes()
 
     def plan_revert_single(self, dt_execution, follows=()):
         """Create a planned operation to revert the present one.

--- a/anyblok_wms_base/core/operation/base.py
+++ b/anyblok_wms_base/core/operation/base.py
@@ -8,7 +8,7 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from anyblok import Declarations
 from anyblok.column import String
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 register = Declarations.register
 Wms = Declarations.Model.Wms
 
-
 NONZERO = NonZero()
+UTC = timezone.utc
 
 
 @Declarations.register(Wms.Operation)
@@ -393,7 +393,7 @@ class Operation:
         """
 
         if state == 'done' or not inputs:
-            return datetime.now()
+            return datetime.now(tz=UTC)
         return max(av.dt_from for av in inputs)
 
     @classmethod
@@ -415,7 +415,7 @@ class Operation:
         if self.state == 'done':
             return
         if dt_execution is None:
-            dt_execution = datetime.now()
+            dt_execution = datetime.now(tz=UTC)
         self.dt_execution = dt_execution
         if self.dt_start is None:
             self.dt_start = dt_execution
@@ -489,7 +489,7 @@ class Operation:
                  start reversing the whole.
         """
         if dt_execution is None:
-            dt_execution = datetime.now()
+            dt_execution = datetime.now(tz=UTC)
         if self.state != 'done':
             # TODO actually it'd be nice to cancel or update
             # planned operations (think of reverting a Move meant for

--- a/anyblok_wms_base/core/operation/base.py
+++ b/anyblok_wms_base/core/operation/base.py
@@ -507,7 +507,8 @@ class Operation:
         exec_leafs = []
         followers_reverts = []
         for follower in self.followers:
-            follower_revert, follower_exec_leafs = follower.plan_revert()
+            follower_revert, follower_exec_leafs = follower.plan_revert(
+                dt_execution=dt_execution)
             self.registry.flush()
             followers_reverts.append(follower_revert)
             exec_leafs.extend(follower_exec_leafs)
@@ -884,6 +885,11 @@ class Operation:
         for follower, avs in followers.items():
             for av in avs:
                 av.dt_from = new_dt
+                dt_until = av.dt_until
+                if dt_until is not None:
+                    # minimal consistent change (follower's alteration
+                    # could change it further)
+                    av.dt_until = max(dt_until, new_dt)
             if follower is not None and new_dt > follower.dt_execution:
                 follower.alter_dt_execution(new_dt)
 

--- a/anyblok_wms_base/core/operation/move.py
+++ b/anyblok_wms_base/core/operation/move.py
@@ -51,6 +51,9 @@ class Move(Mixin.WmsSingleInputOperation,
             # in any case, dt_until should be at least dt_from
             dt_until = max(orig_dt_until, dt_exec)
 
+        to_move.dt_until = dt_exec
+        if state == 'done':
+            to_move.state = 'past'
         self.registry.Wms.PhysObj.Avatar.insert(
             location=self.destination,
             outcome_of=self,
@@ -58,10 +61,6 @@ class Move(Mixin.WmsSingleInputOperation,
             dt_from=dt_exec,
             dt_until=dt_until,
             obj=to_move.obj)
-
-        to_move.dt_until = dt_exec
-        if state == 'done':
-            to_move.state = 'past'
 
     @classmethod
     def check_create_conditions(cls, state, dt_execution, destination=None,
@@ -97,10 +96,8 @@ class Move(Mixin.WmsSingleInputOperation,
     def execute_planned(self):
         dt_execution = self.dt_execution
 
-        self.outcome.update(state='present', dt_from=dt_execution)
-        self.registry.flush()  # TODO should now been unneeded
-
         self.input.update(state='past', dt_until=dt_execution)
+        self.outcome.update(state='present', dt_from=dt_execution)
 
     def is_reversible(self):
         """Moves are always reversible.

--- a/anyblok_wms_base/core/operation/move.py
+++ b/anyblok_wms_base/core/operation/move.py
@@ -43,14 +43,20 @@ class Move(Mixin.WmsSingleInputOperation,
 
     def after_insert(self):
         state, to_move, dt_exec = self.state, self.input, self.dt_execution
+        orig_dt_until = to_move.dt_until
+        if orig_dt_until is None:
+            dt_until = None
+        else:
+            # it's not clear what it means for to_move.dt_until not to be None
+            # in any case, dt_until should be at least dt_from
+            dt_until = max(orig_dt_until, dt_exec)
 
         self.registry.Wms.PhysObj.Avatar.insert(
             location=self.destination,
             outcome_of=self,
             state='present' if state == 'done' else 'future',
             dt_from=dt_exec,
-            # copied fields:
-            dt_until=to_move.dt_until,
+            dt_until=dt_until,
             obj=to_move.obj)
 
         to_move.dt_until = dt_exec

--- a/anyblok_wms_base/core/operation/observation.py
+++ b/anyblok_wms_base/core/operation/observation.py
@@ -104,6 +104,8 @@ class Observation(Mixin.WmsSingleInputOperation,
                 "Observation together with its results (this "
                 "would mean one knows result in advance).")
         dt_exec = self.dt_execution
+
+        inp_av.update(dt_until=dt_exec, state='past')
         physobj.Avatar.insert(
             obj=physobj,
             state='future' if state == 'planned' else 'present',
@@ -111,8 +113,6 @@ class Observation(Mixin.WmsSingleInputOperation,
             location=self.input.location,
             dt_from=dt_exec,
             dt_until=None)
-
-        inp_av.update(dt_until=dt_exec, state='past')
 
         if self.state == 'done':
             self.apply_properties()

--- a/anyblok_wms_base/core/operation/teleportation.py
+++ b/anyblok_wms_base/core/operation/teleportation.py
@@ -76,13 +76,13 @@ class Teleportation(Mixin.WmsSingleInputOperation,
         """
         to_move, dt_exec = self.input, self.dt_execution
 
+        orig_dt_until = to_move.dt_until
+        to_move.update(dt_until=dt_exec, state='past')
         self.registry.Wms.PhysObj.Avatar.insert(
             location=self.new_location,
             outcome_of=self,
             state='present',
             dt_from=dt_exec,
             # copied fields:
-            dt_until=to_move.dt_until,
+            dt_until=orig_dt_until,
             obj=to_move.obj)
-
-        to_move.update(dt_until=dt_exec, state='past')

--- a/anyblok_wms_base/core/operation/tests/test_assembly.py
+++ b/anyblok_wms_base/core/operation/tests/test_assembly.py
@@ -7,7 +7,7 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 import itertools
-from datetime import datetime
+from datetime import datetime, timezone
 
 from anyblok_wms_base.testing import BlokTestCase
 from anyblok_wms_base.testing import WmsTestCase
@@ -1395,7 +1395,7 @@ class TestTypedExpression(BlokTestCase):
         Wms = self.registry.Wms
         self.operation = Wms.Operation.Assembly.insert(
             outcome_type=Wms.PhysObj.Type.insert(code='whatever'),
-            dt_execution=datetime.now(),
+            dt_execution=datetime.now(tz=timezone.utc),
             state='planned')
         self.eval_typed_expr = self.operation.eval_typed_expr
 

--- a/anyblok_wms_base/core/operation/tests/test_move.py
+++ b/anyblok_wms_base/core/operation/tests/test_move.py
@@ -29,7 +29,7 @@ class TestMove(WmsTestCaseWithPhysObj):
         self.assertEqual(new_goods.dt_until, self.dt_test3)
         # TODO also check that id did not change once we can make it True
 
-    def test_whole_planned_execute(self):
+    def test_planned_execute(self):
         move = self.Move.create(destination=self.stock,
                                 state='planned',
                                 dt_execution=self.dt_test2,
@@ -50,7 +50,7 @@ class TestMove(WmsTestCaseWithPhysObj):
                          .count(),
                          0)
 
-    def test_whole_done(self):
+    def test_done(self):
         self.avatar.update(state='present')
         move = self.Move.create(destination=self.stock,
                                 state='done',
@@ -65,7 +65,7 @@ class TestMove(WmsTestCaseWithPhysObj):
         not_moved = move.input
         self.assertEqual(not_moved.state, 'past')
 
-    def test_whole_done_obliviate(self):
+    def test_done_obliviate(self):
         self.avatar.state = 'present'
         move = self.Move.create(destination=self.stock,
                                 state='done',
@@ -73,7 +73,7 @@ class TestMove(WmsTestCaseWithPhysObj):
         move.obliviate()
         self.assertBackToBeginning()
 
-    def test_whole_planned_execute_obliviate(self):
+    def test_planned_execute_obliviate(self):
         move = self.Move.create(destination=self.stock,
                                 dt_execution=self.dt_test2,
                                 state='planned',

--- a/anyblok_wms_base/core/operation/tests/test_operation.py
+++ b/anyblok_wms_base/core/operation/tests/test_operation.py
@@ -200,16 +200,15 @@ class TestOperation(WmsTestCase):
                                                 dt_execution=self.dt_test1,
                                                 state='done')
 
-        goods = self.assert_singleton(arrival.outcomes)  # an Avatar, really
         Move = self.Operation.Move
 
         # full moves don't generate splits, that's why the history is linear
         # (Splits are in wms-quantity only, now, anyway)
-        move1 = Move.create(input=goods,
+        move1 = Move.create(input=arrival.outcome,
                             dt_execution=self.dt_test2,
                             destination=self.stock,
                             state='done')
-        move2 = Move.create(input=self.assert_singleton(move1.outcomes),
+        move2 = Move.create(input=move1.outcome,
                             dt_execution=self.dt_test3,
                             destination=workshop,
                             state='done')

--- a/anyblok_wms_base/core/operation/tests/test_single_input.py
+++ b/anyblok_wms_base/core/operation/tests/test_single_input.py
@@ -26,23 +26,29 @@ class TestSingleInputOperation(WmsTestCaseWithPhysObj):
         self.op_model_name = 'Model.Wms.Operation.Move'
         self.Move = self.registry.Wms.Operation.Move
 
-    def test_create_input_inputs(self):
-        """Test that in create(), the input and inputs kwargs work."""
+    def create(self, state='done', **kwargs):
+        self.avatar.state = 'present'
+        return self.Move.create(destination=self.stock,
+                                state='done', **kwargs)
+
+    def test_create_input(self):
+        """Test that in create(), the input kwarg works."""
         avatar = self.avatar
-
-        def create(**kwargs):
-            avatar.state = 'present'
-            return self.Move.create(destination=self.stock,
-                                    state='done', **kwargs)
-
-        move = create(input=avatar)
+        move = self.create(input=avatar)
         self.assertEqual(move.inputs, [avatar])
 
-        move = create(inputs=[avatar])
+    def test_create_inputs(self):
+        """Test that in create(), the inputs kwarg works."""
+        avatar = self.avatar
+        move = self.create(inputs=[avatar])
         self.assertEqual(move.inputs, [avatar])
 
+    def test_create_both_input_args(self):
+        """Test that in create(), using both input and inputs kwars is an error.
+        """
+        avatar = self.avatar
         with self.assertRaises(OperationError) as arc:
-            create(inputs=[avatar], input=avatar)
+            self.create(inputs=[avatar], input=avatar)
         self.assertEqual(arc.exception.kwargs,
                          dict(input=avatar, inputs=[avatar]))
 

--- a/anyblok_wms_base/core/physobj/main.py
+++ b/anyblok_wms_base/core/physobj/main.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 import warnings
 
 from sqlalchemy import CheckConstraint
+from sqlalchemy import Index
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy import orm
 from sqlalchemy import or_
@@ -711,6 +712,9 @@ class Avatar:
         return super().define_table_args() + (
                 CheckConstraint('dt_until IS NULL OR dt_until >= dt_from',
                                 name='dt_range_valid'),
+                Index("idx_avatar_present_unique",
+                      cls.obj_id, unique=True,
+                      postgresql_where=(cls.state == 'present'))
             )
 
     def _goods_get(self):

--- a/anyblok_wms_base/core/physobj/main.py
+++ b/anyblok_wms_base/core/physobj/main.py
@@ -9,6 +9,7 @@
 from copy import deepcopy
 import warnings
 
+from sqlalchemy import CheckConstraint
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy import orm
 from sqlalchemy import or_
@@ -704,6 +705,13 @@ class Avatar:
     This does not extend to compatibility of the former low level ``goods_id``
     column.
     """
+
+    @classmethod
+    def define_table_args(cls):
+        return super().define_table_args() + (
+                CheckConstraint('dt_until IS NULL OR dt_until >= dt_from',
+                                name='dt_range_valid'),
+            )
 
     def _goods_get(self):
         deprecation_warn_goods()

--- a/anyblok_wms_base/core/tests/__init__.py
+++ b/anyblok_wms_base/core/tests/__init__.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-from datetime import datetime
+from datetime import datetime, timezone
 from anyblok.blok import BlokManager
 from anyblok.tests.testcase import BlokTestCase
 
@@ -21,9 +21,10 @@ class TestCore(BlokTestCase):
 
         location_type = Wms.PhysObj.Type.insert(code="LOC")
         loc = Wms.PhysObj.insert(code="Root", type=location_type)
+        now = datetime.now(tz=timezone.utc)
         arrival = Wms.Operation.Arrival.insert(physobj_type=physobj_type,
                                                location=loc,
-                                               dt_execution=datetime.now(),
+                                               dt_execution=now,
                                                state='done')
         # basic test of polymorphism
         op = Wms.Operation.query().get(arrival.id)

--- a/anyblok_wms_base/reservation/tests/test_request.py
+++ b/anyblok_wms_base/reservation/tests/test_request.py
@@ -163,7 +163,8 @@ class RequestItemTestCase(WmsTestCase):
         """We don't reserve several times PhysObj that have several Avatars."""
         goods = self.goods[self.props1][0]
         for av in self.avatars.values():
-            av.obj = goods
+            # can't have several 'present' Avatars for one physicial object
+            av.update(state='future', obj=goods)
         self.registry.flush()  # to be sure
 
         item = self.RequestItem(goods_type=self.goods_type1,

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -12,6 +12,10 @@ Release history
 0.9.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
+* consistency of date/time ranges of Avatars is now strongly
+  guaranteed (database constraint). In particular, they are
+  now maintained when an Operation's date of execution changes
+  (see also https://github.com/AnyBlok/anyblok_wms_base/issues/8)
 * doc: contributor's guide
 
 0.8.0

--- a/doc/CHANGES.rst
+++ b/doc/CHANGES.rst
@@ -12,10 +12,14 @@ Release history
 0.9.0 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-* consistency of date/time ranges of Avatars is now strongly
-  guaranteed (database constraint). In particular, they are
-  now maintained when an Operation's date of execution changes
-  (see also https://github.com/AnyBlok/anyblok_wms_base/issues/8)
+* Database constraints:
+
+  + consistency of date/time ranges of Avatars.
+    In particular, they are now maintained when an Operation's date of
+    execution changes
+    (see also https://github.com/AnyBlok/anyblok_wms_base/issues/8).
+  + at most one Avatar in the ``present`` state for a given physical object.
+
 * doc: contributor's guide
 
 0.8.0


### PR DESCRIPTION
Minimal (in terms of development) way of maintaining consistency when execution date/times of Operations change, in othe words, solving #8

Also two new database constraints:

* that `dt_until >= dt_from`
* that there can be at most one Avatar in the `present` state for a given physical object (that last one could have been a distinct PR, yes)
