### PR TITLE
Lift requirement for SQLAlchemy < 1.3

### DIFF
--- a/anyblok_wms_base/anyblok_forward_ports/__init__.py
+++ b/anyblok_wms_base/anyblok_forward_ports/__init__.py
@@ -7,19 +7,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-from unittest import SkipTest
-
-
-def skip_unless_bloks_installed(*bloks):
-    def bloks_decorator(testmethod):
-        def wrapped(self):
-            Blok = self.registry.System.Blok
-            for blok_name in bloks:
-                blok = Blok.query().get(blok_name)
-                if blok.state != 'installed':
-                    raise SkipTest("Blok %r is not installed" % blok_name)
-            return testmethod(self)
-        # necessary not to be ignored by test runner
-        wrapped.__name__ = testmethod.__name__
-        return wrapped
-    return bloks_decorator

--- a/anyblok_wms_base/testing.py
+++ b/anyblok_wms_base/testing.py
@@ -14,10 +14,7 @@ import anyblok.registry
 from anyblok.config import Configuration
 from anyblok.tests.testcase import BlokTestCase
 from anyblok.tests.testcase import SharedDataTestCase
-try:
-    from anyblok.tests.testcase import skip_unless_bloks_installed
-except ImportError:  # pragma: no cover
-    from .anyblok_forward_ports import skip_unless_bloks_installed  # noqa
+from anyblok.tests.testcase import skip_unless_bloks_installed  # noqa
 
 _missing = object()
 UTC = timezone.utc

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,8 @@ anyblok_init = [
 ]
 
 requirements = [
-    'anyblok>=0.20.0',
+    'anyblok>=0.22.0',
     'anyblok_postgres',
-    'SQLAlchemy<1.3',
 ]
 
 # it is a bit lame, because ideally we'd prefer to


### PR DESCRIPTION
Since it's been added, the compatibility of AnyBlok with
SQLAlchemy 1.3 has been fixed (in AnyBlok 0.21.0) and SQLAlchemy
1.3 has become the minimal AnyBlok supported version

AWB tests seem to fail on AnyBlok 0.21.0, so let's jump straight
to 0.22.0