### PR TITLE
WIP Avatar timespan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
 
 script:
   - flake8 anyblok_wms_base
+  - psql -c "CREATE EXTENSION btree_gist" template1
   - python3 run_all_tests.py -- -v
 
 after_success:

--- a/anyblok_wms_base/__init__.py
+++ b/anyblok_wms_base/__init__.py
@@ -7,4 +7,5 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
-version = '0.9.0.dev1'
+version = '0.10.0.dev1'  # this comment to make a conflict forcing me to review
+                         # before merge

--- a/anyblok_wms_base/__init__.py
+++ b/anyblok_wms_base/__init__.py
@@ -8,4 +8,4 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 version = '0.10.0.dev1'  # this comment to make a conflict forcing me to review
-                         # before merge
+# before merge

--- a/anyblok_wms_base/constants.py
+++ b/anyblok_wms_base/constants.py
@@ -21,6 +21,7 @@ as keys for a display system (with i18n in mind), such as
 ``wms_op_type_pack``.
 
 """
+from .dbapi import DATE_TIME_INFINITY  # noqa (reexport)
 
 AVATAR_STATES = dict(past="wms_avatar_states_past",
                      present="wms_avatar_states_present",
@@ -79,14 +80,6 @@ they are prefixed with ``wms_``.
 """
 
 SPLIT_AGGREGATE_PHYSICAL_BEHAVIOUR = 'split_aggregate_physical'
-
-DATE_TIME_INFINITY = object()
-"""A marker used to represent +infinity date/time.
-
-For instance, if a method is used to query Avatars for a given date, using
-this marker in the interface is more explicit than using None (which could
-also mean one does not care about dates).
-"""
 
 
 DEFAULT_ASSEMBLY_NAME = 'default'

--- a/anyblok_wms_base/constants.py
+++ b/anyblok_wms_base/constants.py
@@ -21,7 +21,11 @@ as keys for a display system (with i18n in mind), such as
 ``wms_op_type_pack``.
 
 """
-from .dbapi import DATE_TIME_INFINITY  # noqa (reexport)
+from .dbapi import (  # noqa (re-exports)
+    DATE_TIME_INFINITY,
+    EMPTY_TIMESPAN,
+    )
+
 
 AVATAR_STATES = dict(past="wms_avatar_states_past",
                      present="wms_avatar_states_present",

--- a/anyblok_wms_base/core/operation/arrival.py
+++ b/anyblok_wms_base/core/operation/arrival.py
@@ -186,7 +186,7 @@ class Arrival(Mixin.WmsSingleOutcomeOperation, Operation):
         )
 
     def execute_planned(self):
-        self.outcome.update(state='present', dt_from=self.dt_execution)
+        self.outcome.state = 'present'
 
     @classmethod
     def refine_with_trailing_unpack(cls, arrivals, pack_type,

--- a/anyblok_wms_base/core/operation/assembly.py
+++ b/anyblok_wms_base/core/operation/assembly.py
@@ -930,14 +930,11 @@ class Assembly(Mixin.WmsSingleOutcomeOperation, Operation):
 
     def after_insert(self):
         state = self.state
-        outcome_state = 'present' if state == 'done' else 'future'
-        dt_exec = self.dt_execution
-        input_upd = dict(dt_until=dt_exec)
-        if state == 'done':
-            input_upd.update(state='past')
         # TODO PERF bulk update ?
-        for inp in self.inputs:
-            inp.update(**input_upd)
+        # TODO move this also to the base class
+        if state == 'done':
+            for inp in self.inputs:
+                inp.state = 'past'
 
         self.check_match_inputs(state, for_creation=True)
         PhysObj = self.registry.Wms.PhysObj
@@ -948,9 +945,9 @@ class Assembly(Mixin.WmsSingleOutcomeOperation, Operation):
                     **self.outcome_properties(state, for_creation=True))),
             location=self.outcome_location(),
             outcome_of=self,
-            state=outcome_state,
-            dt_from=dt_exec,
-            dt_until=None)
+            state='present' if state == 'done' else 'future',
+            dt_from=self.dt_execution,
+            )
 
     def outcome_location(self):
         """Find where the new assembled physical object should appear.

--- a/anyblok_wms_base/core/operation/base.py
+++ b/anyblok_wms_base/core/operation/base.py
@@ -48,12 +48,14 @@ class HistoryInput:
     """
     operation = Many2One(model='Model.Wms.Operation',
                          index=True,
+                         nullable=False,
                          primary_key=True,
                          foreign_key_options={'ondelete': 'cascade'})
     """The Operation we are interested in."""
 
     avatar = Many2One(model='Model.Wms.PhysObj.Avatar',
                       primary_key=True,
+                      nullable=False,
                       foreign_key_options={'ondelete': 'cascade'})
     """One of the inputs of the :attr:`operation`."""
 

--- a/anyblok_wms_base/core/operation/base.py
+++ b/anyblok_wms_base/core/operation/base.py
@@ -882,11 +882,16 @@ class Operation:
         self.check_alterable()
         self.dt_execution = new_dt
         for av in self.inputs:
-            if av.dt_from > new_dt:
-                # TODO more precise exc
-                raise OperationError(self,
-                                     "Can't alter dt_execution to "
-                                     "before input presence time")
+            if av.dt_from is not None:
+                # av.dt_from can be None if av.timespan is empty,
+                # which makes this sanity check not that useful anymore
+                # TODO use av.outcome_of.dt_execution or introduce a new
+                # not_before timestamp
+                if av.dt_from > new_dt:
+                    # TODO more precise exc
+                    raise OperationError(self,
+                                         "Can't alter dt_execution to "
+                                         "before input presence time")
             av.dt_until = new_dt
         Wms = self.registry.Wms
         Operation = Wms.Operation

--- a/anyblok_wms_base/core/operation/base.py
+++ b/anyblok_wms_base/core/operation/base.py
@@ -884,9 +884,10 @@ class Operation:
         for av in self.inputs:
             if av.dt_from is not None:
                 # av.dt_from can be None if av.timespan is empty,
-                # which makes this sanity check not that useful anymore
-                # TODO use av.outcome_of.dt_execution or introduce a new
-                # not_before timestamp
+                # which makes this sanity check not comprehensive.
+                # On production databases, we expect to have
+                # the strong non-overlapping EXCLUDE constraint, but this check
+                # is still useful as an easier to debug condition.
                 if av.dt_from > new_dt:
                     # TODO more precise exc
                     raise OperationError(self,

--- a/anyblok_wms_base/core/operation/departure.py
+++ b/anyblok_wms_base/core/operation/departure.py
@@ -33,16 +33,13 @@ class Departure(Mixin.WmsSingleInputOperation, Operation):
 
     def depart(self):
         """Common logic for final departure step."""
-        self.input.update(state='past', reason=self,
-                          dt_until=self.dt_execution)
+        self.input.state = 'past'
 
     def after_insert(self):
         """Either finish right away, or represent the future decrease."""
         self.registry.flush()
         if self.state == 'done':
             self.depart()
-        else:
-            self.input.dt_until = self.dt_execution
 
     def execute_planned(self):
         self.registry.flush()

--- a/anyblok_wms_base/core/operation/disparition.py
+++ b/anyblok_wms_base/core/operation/disparition.py
@@ -34,8 +34,7 @@ class Disparition(Mixin.WmsSingleInputOperation,
     def after_insert(self):
         """Put the input Avatar in the 'past' state
         """
-        self.input.update(dt_until=self.dt_execution,
-                          state='past')
+        self.input.state = 'past'
 
     def obliviate_single(self):
         self.reset_inputs_original_values(state='present')

--- a/anyblok_wms_base/core/operation/move.py
+++ b/anyblok_wms_base/core/operation/move.py
@@ -12,7 +12,6 @@ import logging
 from anyblok import Declarations
 from anyblok.column import Integer
 from anyblok.relationship import Many2One
-from anyblok_wms_base.dbapi import TimeSpan
 from anyblok_wms_base.exceptions import (
     OperationError,
     OperationContainerExpected,
@@ -90,21 +89,10 @@ class Move(Mixin.WmsSingleInputOperation,
         return move
 
     def execute_planned(self):
+        # TODO even simplified, this should be standard, and done by base class
+        self.set_outcomes_lower_timespan_bounds()
         self.input.state = 'past'
-        outcome = self.outcome
-        # TODO this should really be done by the base class
-        ts = outcome.timespan
-        if not ts.isempty:
-            upper = ts.upper
-        else:
-            followers = self.followers
-            if followers:  # at most one
-                upper = next(iter(followers)).dt_execution
-
-        outcome.update(state='present',
-                       timespan=TimeSpan(lower=self.dt_execution,
-                                         upper=upper,
-                                         bounds='[)'))
+        self.outcome.state = 'present'
 
     def is_reversible(self):
         """Moves are always reversible.

--- a/anyblok_wms_base/core/operation/move.py
+++ b/anyblok_wms_base/core/operation/move.py
@@ -43,14 +43,6 @@ class Move(Mixin.WmsSingleInputOperation,
 
     def after_insert(self):
         state, to_move, dt_exec = self.state, self.input, self.dt_execution
-        orig_dt_until = to_move.dt_until
-        if orig_dt_until is None:
-            dt_until = None
-        else:
-            # it's not clear what it means for to_move.dt_until not to be None
-            # in any case, dt_until should be at least dt_from
-            dt_until = max(orig_dt_until, dt_exec)
-
         to_move.dt_until = dt_exec
         if state == 'done':
             to_move.state = 'past'
@@ -59,7 +51,7 @@ class Move(Mixin.WmsSingleInputOperation,
             outcome_of=self,
             state='present' if state == 'done' else 'future',
             dt_from=dt_exec,
-            dt_until=dt_until,
+            dt_until=None,
             obj=to_move.obj)
 
     @classmethod
@@ -75,6 +67,8 @@ class Move(Mixin.WmsSingleInputOperation,
 
     @classmethod
     def plan_for_outcomes(cls, inputs, outcomes, dt_execution=None, **fields):
+        # TODO this should really go to single_outcome, there's nothing
+        # special about this
         if len(outcomes) != 1:
             raise OperationError(
                 cls, "can't plan for {nb_outcomes} outcomes, would need "

--- a/anyblok_wms_base/core/operation/move.py
+++ b/anyblok_wms_base/core/operation/move.py
@@ -90,7 +90,6 @@ class Move(Mixin.WmsSingleInputOperation,
 
     def execute_planned(self):
         # TODO even simplified, this should be standard, and done by base class
-        self.set_outcomes_lower_timespan_bounds()
         self.input.state = 'past'
         self.outcome.state = 'present'
 

--- a/anyblok_wms_base/core/operation/move.py
+++ b/anyblok_wms_base/core/operation/move.py
@@ -43,7 +43,6 @@ class Move(Mixin.WmsSingleInputOperation,
 
     def after_insert(self):
         state, to_move, dt_exec = self.state, self.input, self.dt_execution
-        to_move.dt_until = dt_exec
         if state == 'done':
             to_move.state = 'past'
         self.registry.Wms.PhysObj.Avatar.insert(
@@ -51,7 +50,6 @@ class Move(Mixin.WmsSingleInputOperation,
             outcome_of=self,
             state='present' if state == 'done' else 'future',
             dt_from=dt_exec,
-            dt_until=None,
             obj=to_move.obj)
 
     @classmethod
@@ -90,7 +88,7 @@ class Move(Mixin.WmsSingleInputOperation,
     def execute_planned(self):
         dt_execution = self.dt_execution
 
-        self.input.update(state='past', dt_until=dt_execution)
+        self.input.state = 'past'
         self.outcome.update(state='present', dt_from=dt_execution)
 
     def is_reversible(self):

--- a/anyblok_wms_base/core/operation/observation.py
+++ b/anyblok_wms_base/core/operation/observation.py
@@ -159,9 +159,8 @@ class Observation(Mixin.WmsSingleInputOperation,
 
     def execute_planned(self):
         self.apply_properties()
-        dt_exec = self.dt_execution
         self.input.state = 'past'
-        self.outcome.update(dt_from=dt_exec, state='present')
+        self.outcome.state = 'present'
 
     def obliviate_single(self):
         """Restore the Properties as they were before execution.

--- a/anyblok_wms_base/core/operation/observation.py
+++ b/anyblok_wms_base/core/operation/observation.py
@@ -105,14 +105,13 @@ class Observation(Mixin.WmsSingleInputOperation,
                 "would mean one knows result in advance).")
         dt_exec = self.dt_execution
 
-        inp_av.update(dt_until=dt_exec, state='past')
+        inp_av.state = 'past'
         physobj.Avatar.insert(
             obj=physobj,
             state='future' if state == 'planned' else 'present',
             outcome_of=self,
             location=self.input.location,
-            dt_from=dt_exec,
-            dt_until=None)
+            dt_from=dt_exec)
 
         if self.state == 'done':
             self.apply_properties()
@@ -160,7 +159,7 @@ class Observation(Mixin.WmsSingleInputOperation,
     def execute_planned(self):
         self.apply_properties()
         dt_exec = self.dt_execution
-        self.input.update(dt_until=dt_exec, state='past')
+        self.input.state = 'past'
         self.outcome.update(dt_from=dt_exec, state='present')
 
     def obliviate_single(self):

--- a/anyblok_wms_base/core/operation/observation.py
+++ b/anyblok_wms_base/core/operation/observation.py
@@ -105,7 +105,8 @@ class Observation(Mixin.WmsSingleInputOperation,
                 "would mean one knows result in advance).")
         dt_exec = self.dt_execution
 
-        inp_av.state = 'past'
+        if state == 'done':
+            inp_av.state = 'past'
         physobj.Avatar.insert(
             obj=physobj,
             state='future' if state == 'planned' else 'present',

--- a/anyblok_wms_base/core/operation/single_input.py
+++ b/anyblok_wms_base/core/operation/single_input.py
@@ -89,10 +89,13 @@ class WmsSingleInputOperation:
         """
         self.check_alterable()
         move = self.registry.Wms.Operation.Move.create(
+            terminal=False,
             input=self.input,
             destination=stopover,
             dt_execution=self.dt_execution,
             state='planned')
-        self.link_inputs(move.outcomes, clear=True)
+        new_inputs = move.outcomes
+        self.link_inputs(new_inputs, clear=True)
+        self.set_inputs_upper_timespan_bounds(new_inputs)
         self.input_location_altered()
         return move

--- a/anyblok_wms_base/core/operation/single_outcome.py
+++ b/anyblok_wms_base/core/operation/single_outcome.py
@@ -13,6 +13,7 @@ from anyblok import Declarations
 from anyblok_wms_base.exceptions import (
     OperationError,
     )
+from anyblok_wms_base.constants import EMPTY_TIMESPAN
 
 Mixin = Declarations.Mixin
 Model = Declarations.Model
@@ -43,6 +44,7 @@ class WmsSingleOutcomeOperation:
 
         :param stopover: this is the location of the intermediate Avatar
                          that's been introduced (starting point of the Move).
+        :param dt_execution: TODO not supported yet
         :returns: the new Move instance
 
         This doesn't change anything for the followers of the current
@@ -56,6 +58,7 @@ class WmsSingleOutcomeOperation:
         destination. This is especially useful if the landing area can't be
         determined at the time of the original planning, or simply to follow
         the general principle of sober planning.
+
         """
         self.check_alterable()
         field = self.destination_field
@@ -67,13 +70,13 @@ class WmsSingleOutcomeOperation:
                 op=self)
         setattr(self, field, stopover)
 
-        outcome = self.outcome
-        new_outcome = self.registry.Wms.PhysObj.Avatar.insert(
+        final_outcome = self.outcome
+        stopover_outcome = self.registry.Wms.PhysObj.Avatar.insert(
             location=stopover,
             outcome_of=self,
             state='future',
-            dt_from=self.dt_execution,
-            dt_until=self.dt_execution,
-            obj=outcome.obj)
+            timespan=EMPTY_TIMESPAN,
+            obj=final_outcome.obj)
         return self.registry.Wms.Operation.Move.plan_for_outcomes(
-            (new_outcome, ), (outcome, ), dt_execution=self.dt_execution)
+            (stopover_outcome, ), (final_outcome, ),
+            dt_execution=self.dt_execution)

--- a/anyblok_wms_base/core/operation/single_outcome.py
+++ b/anyblok_wms_base/core/operation/single_outcome.py
@@ -73,8 +73,7 @@ class WmsSingleOutcomeOperation:
             outcome_of=self,
             state='future',
             dt_from=self.dt_execution,
-            # copied fields:
-            dt_until=outcome.dt_until,
+            dt_until=self.dt_execution,
             obj=outcome.obj)
         return self.registry.Wms.Operation.Move.plan_for_outcomes(
             (new_outcome, ), (outcome, ), dt_execution=self.dt_execution)

--- a/anyblok_wms_base/core/operation/teleportation.py
+++ b/anyblok_wms_base/core/operation/teleportation.py
@@ -64,11 +64,10 @@ class Teleportation(Mixin.WmsSingleInputOperation,
         """
         to_move, dt_exec = self.input, self.dt_execution
 
-        to_move.update(dt_until=dt_exec, state='past')
+        to_move.state = 'past'
         self.registry.Wms.PhysObj.Avatar.insert(
             location=self.new_location,
             outcome_of=self,
             state='present',
             dt_from=dt_exec,
-            dt_until=None,
             obj=to_move.obj)

--- a/anyblok_wms_base/core/operation/teleportation.py
+++ b/anyblok_wms_base/core/operation/teleportation.py
@@ -64,13 +64,11 @@ class Teleportation(Mixin.WmsSingleInputOperation,
         """
         to_move, dt_exec = self.input, self.dt_execution
 
-        orig_dt_until = to_move.dt_until
         to_move.update(dt_until=dt_exec, state='past')
         self.registry.Wms.PhysObj.Avatar.insert(
             location=self.new_location,
             outcome_of=self,
             state='present',
             dt_from=dt_exec,
-            # copied fields:
-            dt_until=orig_dt_until,
+            dt_until=None,
             obj=to_move.obj)

--- a/anyblok_wms_base/core/operation/tests/test_alter_planning.py
+++ b/anyblok_wms_base/core/operation/tests/test_alter_planning.py
@@ -163,6 +163,7 @@ class TestAlterPlanning(WmsTestCaseWithPhysObj):
         dep2 = self.Operation.Departure.create(input=unp_outcomes[1],
                                                dt_execution=self.dt_test3)
 
+        self.assertEqual(unp_input.dt_until, unp.dt_execution)
         arrival.alter_dt_execution(new_arrival_dt)
 
         self.assertEqual(unp_input.timespan, EMPTY_TIMESPAN)

--- a/anyblok_wms_base/core/operation/tests/test_alter_planning.py
+++ b/anyblok_wms_base/core/operation/tests/test_alter_planning.py
@@ -246,18 +246,20 @@ class TestAlterPlanning(WmsTestCaseWithPhysObj):
         self.assert_singleton(dep.follows, value=new_move)
 
         # follower's input hasn't changed (same instance)
+        # but is now the move outcome
         self.assert_singleton(dep.inputs, value=dep_input)
 
         # about the new intermediate Avatar
-        new_av = self.assert_singleton(move.outcomes)
+        new_av = move.outcome
         self.assertNotEqual(new_av, dep_input)
         self.assertEqual(new_av.location, stock)
         self.assertEqual(new_av.obj, dep_input.obj)
         self.assertEqual(new_av.dt_from, self.avatar.dt_until)
-        self.assertEqual(new_av.dt_until, self.dt_test3)
+        self.assertEqual(new_av.dt_until, new_move.dt_execution)
 
         self.assertEqual(dep_input.outcome_of, new_move)
         self.assertEqual(new_move.input, new_av)
+        self.assertEqual(dep_input.dt_until, self.dt_test3)
 
     def test_refine_with_leading_move(self):
         outgoing = self.insert_location('OUTGOING')

--- a/anyblok_wms_base/core/operation/tests/test_assembly.py
+++ b/anyblok_wms_base/core/operation/tests/test_assembly.py
@@ -1095,6 +1095,10 @@ class TestAssembly(WmsTestCase):
                                  name='default',
                                  dt_execution=self.dt_test1,
                                  state='planned')
+        # Necessary cleanup
+        for avatar in avatars:
+            avatar.dt_until = None
+
         exc = arc.exception
         str(exc)
         repr(exc)

--- a/anyblok_wms_base/core/operation/tests/test_departure.py
+++ b/anyblok_wms_base/core/operation/tests/test_departure.py
@@ -68,17 +68,16 @@ class TestDeparture(WmsTestCaseWithPhysObj):
 
     def test_whole_planned_cancel(self):
         self.avatar.state = 'present'
-        self.avatar.dt_until = self.dt_test3
         dep = self.Departure.create(state='planned',
                                     dt_execution=self.dt_test2,
                                     input=self.avatar)
         dep.cancel()
 
-        new_goods = self.single_result(self.Avatar.query())
-        self.assertEqual(new_goods.state, 'present')
-        self.assertEqual(new_goods.dt_from, self.dt_test1)
-        self.assertEqual(new_goods.dt_until, self.dt_test3)
-        self.assertEqual(new_goods.location, self.incoming_loc)
+        self.assertEqual(self.single_result(self.Avatar.query()), self.avatar)
+        self.assertEqual(self.avatar.state, 'present')
+        self.assertEqual(self.avatar.dt_from, self.dt_test1)
+        self.assertIsNone(self.avatar.dt_until)
+        self.assertEqual(self.avatar.location, self.incoming_loc)
 
     def test_whole_done(self):
         self.avatar.update(state='present')
@@ -100,10 +99,12 @@ class TestDeparture(WmsTestCaseWithPhysObj):
                                     dt_execution=self.dt_test2,
                                     input=self.avatar)
         dep.obliviate()
-        new_goods = self.single_result(self.Avatar.query())
-        self.assertEqual(new_goods.state, 'present')
-        self.assertEqual(new_goods.dt_from, self.dt_test1)
-        self.assertEqual(new_goods.location, self.incoming_loc)
+
+        self.assertEqual(self.single_result(self.Avatar.query()), self.avatar)
+        self.assertEqual(self.avatar.state, 'present')
+        self.assertEqual(self.avatar.dt_from, self.dt_test1)
+        self.assertIsNone(self.avatar.dt_until)
+        self.assertEqual(self.avatar.location, self.incoming_loc)
 
     def test_repr(self):
         dep = self.Departure.create(state='planned',

--- a/anyblok_wms_base/core/operation/tests/test_move.py
+++ b/anyblok_wms_base/core/operation/tests/test_move.py
@@ -19,14 +19,14 @@ class TestMove(WmsTestCaseWithPhysObj):
     def setUp(self):
         super(TestMove, self).setUp()
         self.Move = self.Operation.Move
-        self.avatar.dt_until = self.dt_test3
 
     def assertBackToBeginning(self):
-        new_goods = self.single_result(self.Avatar.query())
-        self.assertEqual(new_goods.location, self.incoming_loc)
-        self.assertEqual(new_goods.state, 'present')
-        self.assertEqual(new_goods.dt_from, self.dt_test1)
-        self.assertEqual(new_goods.dt_until, self.dt_test3)
+        avatar = self.single_result(self.Avatar.query())
+        self.assertEqual(avatar, self.avatar)
+        self.assertEqual(avatar.location, self.incoming_loc)
+        self.assertEqual(avatar.state, 'present')
+        self.assertEqual(avatar.dt_from, self.dt_test1)
+        self.assertIsNone(avatar.dt_until)
         # TODO also check that id did not change once we can make it True
 
     def test_planned_execute(self):

--- a/anyblok_wms_base/core/operation/tests/test_observation.py
+++ b/anyblok_wms_base/core/operation/tests/test_observation.py
@@ -40,6 +40,15 @@ class TestObservation(WmsTestCaseWithPhysObj):
         self.assertEqual(self.avatar.state, 'past')
         self.assertEqual(outcome.state, 'present')
 
+    def test_planned_input_present(self):
+        self.avatar.state = 'present'
+        obs = self.Observation.create(state='planned',
+                                      dt_execution=self.dt_test2,
+                                      input=self.avatar)
+
+        self.assertEqual(obs.outcome.state, 'future')
+        self.assertEqual(obs.input.state, 'present')
+
     def test_done(self):
         self.avatar.state = 'present'
         obs = self.Observation.create(state='done',

--- a/anyblok_wms_base/core/operation/tests/test_operation.py
+++ b/anyblok_wms_base/core/operation/tests/test_operation.py
@@ -240,6 +240,7 @@ class TestOperation(WmsTestCase):
         self.assert_singleton(move1_rev.follows, value=move2_rev)
 
         move2_rev.execute(self.dt_test3 + timedelta(1))
+
         rev_dt2 = self.dt_test3 + timedelta(2)
         move1_rev.execute(rev_dt2)
 

--- a/anyblok_wms_base/core/operation/tests/test_single_input.py
+++ b/anyblok_wms_base/core/operation/tests/test_single_input.py
@@ -81,7 +81,7 @@ class TestSingleInputOperation(WmsTestCaseWithPhysObj):
         exc = arc.exception
         self.assertEqual(exc.model_name, self.op_model_name)
 
-    def test_whole_planned_execute_but_not_ready(self):
+    def test_planned_execute_but_not_ready(self):
         # TODO should go to test_operation
         move = self.Move.create(destination=self.stock,
                                 dt_execution=self.dt_test2,

--- a/anyblok_wms_base/core/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/core/operation/tests/test_unpack.py
@@ -282,6 +282,7 @@ class TestUnpack(WmsTestCase):
         # No property at all, we fail explicitely
         with self.assertRaises(OperationInputsError) as arc:
             unpack()
+        self.packs.dt_until = None  # restoration
         str(arc.exception)
         repr(arc.exception)
         exc_kwargs = arc.exception.kwargs

--- a/anyblok_wms_base/core/operation/unpack.py
+++ b/anyblok_wms_base/core/operation/unpack.py
@@ -113,7 +113,6 @@ class Unpack(Mixin.WmsSingleInputOperation,
         PhysObj = self.registry.Wms.PhysObj
         PhysObjType = PhysObj.Type
         packs = self.input
-        dt_execution = self.dt_execution
         spec = self.get_outcome_specs()
         type_codes = set(outcome['type'] for outcome in spec)
         outcome_types = {gt.code: gt
@@ -127,7 +126,6 @@ class Unpack(Mixin.WmsSingleInputOperation,
         for outcome_spec in spec:
             self.create_outcomes_for_spec(
                 outcome_types, outcome_spec, outcome_state)
-        packs.dt_until = dt_execution
 
     def create_outcomes_for_spec(self, types_cache, spec, outcome_state):
         PhysObj = self.registry.Wms.PhysObj

--- a/anyblok_wms_base/core/operation/unpack.py
+++ b/anyblok_wms_base/core/operation/unpack.py
@@ -144,7 +144,6 @@ class Unpack(Mixin.WmsSingleInputOperation,
                                   location=packs.location,
                                   outcome_of=self,
                                   dt_from=self.dt_execution,
-                                  dt_until=packs.dt_until,
                                   state=outcome_state)
             if not clone:
                 physobj.update_properties(self.outcome_props_update(spec))

--- a/anyblok_wms_base/core/physobj/main.py
+++ b/anyblok_wms_base/core/physobj/main.py
@@ -759,10 +759,9 @@ class Avatar:
 
     def _dt_until_set(self, v):
         ts = self.timespan
-        if ts.isempty:
+        if ts.isempty and v is not None:
             # TODO precise exc
             raise RuntimeError("Avatar timespan lower bound can't be None")
-            ts = self.timespan = TimeSpan(upper=v, bounds='[)')
         # TODO the underscore certainly means it's not recommended, look
         # into that
         ts._upper = v

--- a/anyblok_wms_base/core/physobj/main.py
+++ b/anyblok_wms_base/core/physobj/main.py
@@ -7,20 +7,17 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 from copy import deepcopy
-from datetime import datetime, timezone
 import warnings
 
-from sqlalchemy import CheckConstraint
 from sqlalchemy import Index
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy import orm
-from sqlalchemy import or_
+from sqlalchemy.dialects.postgresql import ExcludeConstraint
 
 from anyblok import Declarations
 from anyblok.column import Text
 from anyblok.column import Selection
 from anyblok.column import Integer
-from anyblok.column import DateTime
 from anyblok.relationship import Many2One
 from anyblok.field import Function
 from anyblok_postgres.column import Jsonb, TsTzRange
@@ -644,15 +641,16 @@ class Avatar:
     """
 
     timespan = TsTzRange()
+    """Time range during with the Avatar is meaningful.
 
-    dt_from = Function(fget='_dt_from_get',
-                       fset='_dt_from_set',
-                       fexpr='_dt_from_expr')
-    """Date and time from which the Avatar is meaningful, inclusively.
+    The bounds encode date&time with timezone information.
+    At the time of this writing, the lower bound is always inclusive, whereas
+    the upper bound is exclusive, but nothing really enforces that.
 
-    Functionally, even though the default in creating Operations will be
-    to use the current date and time, this is not to be confused with the
-    time of creation in the database, which we don't care much about.
+    The lower bound of this time range is functionally not to be
+    confused with the time of creation in the database, which we don't care
+    much about, even though the default in creating Operations will be
+    to use the current date and time.
 
     The actual meaning really depends on the value of the :attr:`state`
     field:
@@ -668,31 +666,23 @@ class Avatar:
       If the end application does serious time prediction, it can use it
       freely.
 
-    In all cases, this doesn't mean that the very same PhysObj aren't present
-    at an earlier time with the same state, location, etc. That earlier time
-    range would simply be another Avatar (use case: moving back and forth).
+    In all cases, this doesn't mean that the very same :class:`PhysObj`
+    aren't present outside the time range` with the same state, location, etc.
+    That earlier time range would simply be another Avatar, and it would even
+    be incorrect for the core to merge them if adjacent, for traceability
+    reasons (moving back and forth).
+    """
+
+    dt_from = Function(fget='_dt_from_get',
+                       fset='_dt_from_set',
+                       fexpr='_dt_from_expr')
+    """Convenience function field for the lower bound of :attr:`timespan`
     """
 
     dt_until = Function(fget='_dt_until_get',
                         fset='_dt_until_set',
                         fexpr='_dt_until_expr')
-    """Date and time until which the Avatar record is meaningful, exclusively.
-
-    Like :attr:`dt_from`, the meaning varies according to the value of
-    :attr:`state`:
-
-    + In the ``past`` state, this is supposed to be a faithful
-      representation of reality: apart from the special case of formal
-      :ref:`Splits and Aggregates <op_split_aggregate>`, the goods
-      really left this location at these date and time.
-
-    + In the ``present`` and ``future`` states, this is purely
-      theoretical, and the same remarks as for the :attr:`dt_from` field
-      apply readily.
-
-    In all cases, this doesn't mean that the very same goods aren't present
-    at an later time with the same state, location, etc. That later time
-    range would simply be another Avatar (use case: moving back and forth).
+    """Convenience function field for the upper bound of :attr:`timespan`
     """
 
     outcome_of = Many2One(index=True,
@@ -714,11 +704,39 @@ class Avatar:
 
     @classmethod
     def define_table_args(cls):
-        return super().define_table_args() + (
-                Index("idx_avatar_present_unique",
-                      cls.obj_id, unique=True,
-                      postgresql_where=(cls.state == 'present')),
-            )
+        """Add specific indexes and constraints.
+
+        If the ``btree_gist`` PostgreSQL extension is present (a much
+        recommended situation), we can add an exclusion rule that
+        prevents firmly any overlapping of the Avatars of a given Physical
+        Object.
+
+        Installing extensions is done per database by this command::
+
+            CREATE EXTENSION btree_gist;
+
+        but that requires PostgreSQL superuser rights, which the current
+        process may not have, even if it's allowed to create the database.
+        It's possible to pre-add it to `template1`, the default template, or
+        to an explicit one to circumvent the condition.
+        """
+        awb_args = [Index("idx_avatar_present_unique",
+                          cls.obj_id, unique=True,
+                          postgresql_where=(cls.state == 'present')),
+                    ]
+        btree_gist_version = cls.registry.execute(
+            "SELECT extversion FROM pg_catalog.pg_extension "
+            "WHERE extname='btree_gist'").first()
+        if btree_gist_version is None:  # pragma: no cover
+            warnings.warn("Please install the btree_gist PostgreSQL extension "
+                          "(usually packaged in postgresql-contrib or similar) "
+                          "for best consistency checks. "
+                          "Installation requires superuser database rights.")
+        else:
+            # prevent overlapping of avatars for a given Physical Object
+            awb_args.append(ExcludeConstraint(('obj_id', '='),
+                                              ('timespan', '&&')))
+        return super().define_table_args() + tuple(awb_args)
 
     def _dt_from_get(self):
         return self.timespan.lower

--- a/anyblok_wms_base/core/physobj/main.py
+++ b/anyblok_wms_base/core/physobj/main.py
@@ -640,6 +640,9 @@ class Avatar:
     for a discussion of what this should actually mean.
     """
 
+    # default avoid None to occur in intermediate steps before
+    # serialization (seen only in python3.5 and upcoming
+    # refactor will use None anyway as indeterminate marker
     timespan = TsTzRange(nullable=False)
     """Time range during with the Avatar is meaningful.
 
@@ -759,6 +762,12 @@ class Avatar:
 
     def _dt_until_set(self, v):
         ts = self.timespan
+        if ts is None:
+            # can happen during instantiation (only seen with Python3.5
+            # so far). If dt_from is not set later on, some other parts
+            # of AWB should complain, but we have no choice at this point
+            self.timespan = TimeSpan(lower=None, upper=v, bounds='[)')
+            return
         if ts.isempty and v is not None:
             # TODO precise exc
             raise RuntimeError("Avatar timespan lower bound can't be None")

--- a/anyblok_wms_base/core/physobj/tests/test_avatar.py
+++ b/anyblok_wms_base/core/physobj/tests/test_avatar.py
@@ -108,9 +108,10 @@ class TestAvatar(WmsTestCaseWithPhysObj):
 
         with warnings.catch_warnings(record=True) as got:
             # writing
+            avatar.dt_until = self.dt_test2  # avoid overlap
             self.Avatar.insert(goods=phobj,
                                state='present',
-                               dt_from=self.dt_test1,
+                               dt_from=self.dt_test2,
                                dt_until=None,
                                outcome_of=avatar.outcome_of,
                                location=avatar.location)

--- a/anyblok_wms_base/core/physobj/tests/test_avatar.py
+++ b/anyblok_wms_base/core/physobj/tests/test_avatar.py
@@ -120,13 +120,6 @@ class TestAvatar(WmsTestCaseWithPhysObj):
                              2)
         assert_warnings_goods_deprecation(got)
 
-    def test_infinity(self):  # TODO NOCOMMIT shouldn't be here
-        from anyblok_wms_base.constants import DATE_TIME_INFINITY
-        self.avatar.dt_until = DATE_TIME_INFINITY
-        self.registry.flush()
-        self.avatar.expire()
-        self.assertEqual(self.avatar.dt_until, DATE_TIME_INFINITY)
-
     def test_pysobj_current_avatar(self):
         avatar = self.avatar
         # just to make sure

--- a/anyblok_wms_base/core/physobj/tests/test_avatar.py
+++ b/anyblok_wms_base/core/physobj/tests/test_avatar.py
@@ -8,6 +8,7 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 import warnings
 from anyblok_wms_base.testing import WmsTestCaseWithPhysObj
+from anyblok_wms_base.constants import EMPTY_TIMESPAN
 
 
 class TestAvatar(WmsTestCaseWithPhysObj):
@@ -49,7 +50,7 @@ class TestAvatar(WmsTestCaseWithPhysObj):
 
         self.assertEqual(avatar.dt_from, self.dt_test2)
 
-        avatar.timespan = None
+        avatar.timespan = EMPTY_TIMESPAN
         self.registry.flush()
         avatar.expire()
 
@@ -70,16 +71,12 @@ class TestAvatar(WmsTestCaseWithPhysObj):
 
         self.assertEqual(avatar.dt_until, self.dt_test2)
 
-        avatar.timespan = None
+        avatar.timespan = EMPTY_TIMESPAN
         self.registry.flush()
         avatar.expire()
 
-        avatar.dt_until = self.dt_test3
-        self.assertEqual(avatar.dt_until, self.dt_test3)
-        self.registry.flush()
-        avatar.expire()
-
-        self.assertEqual(avatar.dt_until, self.dt_test3)
+        with self.assertRaises(RuntimeError):
+            avatar.dt_until = self.dt_test3
 
     def test_get_property(self):
         avatar = self.avatar

--- a/anyblok_wms_base/core/physobj/tests/test_avatar.py
+++ b/anyblok_wms_base/core/physobj/tests/test_avatar.py
@@ -39,6 +39,48 @@ class TestAvatar(WmsTestCaseWithPhysObj):
             "dt_range=[%s, None])" % (
                 avatar.id, goods, self.incoming_loc, avatar.dt_from))
 
+    def test_compat_dt_from(self):
+        avatar = self.avatar
+
+        self.assertEqual(avatar.dt_from, self.dt_test1)
+        avatar.dt_from = self.dt_test2
+        self.registry.flush()
+        avatar.expire()
+
+        self.assertEqual(avatar.dt_from, self.dt_test2)
+
+        avatar.timespan = None
+        self.registry.flush()
+        avatar.expire()
+
+        avatar.dt_from = self.dt_test3
+        self.assertEqual(avatar.dt_from, self.dt_test3)
+        self.registry.flush()
+        avatar.expire()
+
+        self.assertEqual(avatar.dt_from, self.dt_test3)
+
+    def test_compat_dt_until(self):
+        avatar = self.avatar
+
+        self.assertEqual(avatar.dt_until, None)
+        avatar.dt_until = self.dt_test2
+        self.registry.flush()
+        avatar.expire()
+
+        self.assertEqual(avatar.dt_until, self.dt_test2)
+
+        avatar.timespan = None
+        self.registry.flush()
+        avatar.expire()
+
+        avatar.dt_until = self.dt_test3
+        self.assertEqual(avatar.dt_until, self.dt_test3)
+        self.registry.flush()
+        avatar.expire()
+
+        self.assertEqual(avatar.dt_until, self.dt_test3)
+
     def test_get_property(self):
         avatar = self.avatar
         self.assertIsNone(avatar.get_property('foo'))
@@ -79,6 +121,13 @@ class TestAvatar(WmsTestCaseWithPhysObj):
             self.assertEqual(self.Avatar.query().filter_by(goods=phobj).count(),
                              2)
         assert_warnings_goods_deprecation(got)
+
+    def test_infinity(self):  # TODO NOCOMMIT shouldn't be here
+        from anyblok_wms_base.constants import DATE_TIME_INFINITY
+        self.avatar.dt_until = DATE_TIME_INFINITY
+        self.registry.flush()
+        self.avatar.expire()
+        self.assertEqual(self.avatar.dt_until, DATE_TIME_INFINITY)
 
     def test_pysobj_current_avatar(self):
         avatar = self.avatar

--- a/anyblok_wms_base/core/tests/test_dbapi.py
+++ b/anyblok_wms_base/core/tests/test_dbapi.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# This file is a part of the AnyBlok / WMS Base project
+#
+#    Copyright (C) 2018 Georges Racinet <gracinet@anybox.fr>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+from anyblok_wms_base.dbapi import (
+    TimeSpan,
+    DATE_TIME_INFINITY,
+    )
+from anyblok_wms_base.testing import WmsTestCaseWithPhysObj
+
+
+class TestDbAPI(WmsTestCaseWithPhysObj):
+
+    def test_dt_infinity_scalar(self):
+        op = self.arrival
+        op.dt_execution = DATE_TIME_INFINITY
+        self.registry.flush()
+        op.refresh()
+        self.assertEqual(op.dt_execution, DATE_TIME_INFINITY)
+
+    def test_dt_infinity_range(self):
+        av = self.avatar
+
+        av.timespan = TimeSpan(lower=self.dt_test1,
+                               upper=DATE_TIME_INFINITY,
+                               bounds='[)')
+        self.registry.flush()
+        av.refresh()
+
+        self.assertEqual(av.timespan.upper, DATE_TIME_INFINITY)
+        self.assertTrue(self.dt_test2 in av.timespan)
+
+        av.timespan = TimeSpan(lower=DATE_TIME_INFINITY,
+                               upper=DATE_TIME_INFINITY,
+                               bounds='[)')
+        self.registry.flush()
+        av.refresh()
+
+        self.assertTrue(av.timespan.isempty)
+        self.assertFalse(DATE_TIME_INFINITY in av.timespan)
+
+        av.timespan = TimeSpan(lower=DATE_TIME_INFINITY,
+                               upper=DATE_TIME_INFINITY,
+                               bounds='[]')
+        self.registry.flush()
+        av.refresh()
+
+        self.assertEqual(av.timespan.upper, DATE_TIME_INFINITY)
+        self.assertEqual(av.timespan.lower, DATE_TIME_INFINITY)
+        self.assertTrue(DATE_TIME_INFINITY in av.timespan)
+
+
+del WmsTestCaseWithPhysObj

--- a/anyblok_wms_base/core/wms.py
+++ b/anyblok_wms_base/core/wms.py
@@ -134,12 +134,8 @@ class Wms:
                     "to specify the 'at_datetime' kwarg".format(
                         additional_states))
 
-        if at_datetime is DATE_TIME_INFINITY:
-            query = query.filter(Avatar.dt_until.is_(None))
-        elif at_datetime is not None:
-            query = query.filter(Avatar.dt_from <= at_datetime,
-                                 or_(Avatar.dt_until.is_(None),
-                                     Avatar.dt_until > at_datetime))
+        if at_datetime is not None:
+            query = query.filter(Avatar.timespan.contains(at_datetime))
         if additional_filter is not None:
             query = additional_filter(query)
         return query

--- a/anyblok_wms_base/core/wms.py
+++ b/anyblok_wms_base/core/wms.py
@@ -6,12 +6,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-from sqlalchemy import or_
 from sqlalchemy import not_
 from sqlalchemy import func
 from sqlalchemy import orm
 from anyblok import Declarations
-from anyblok_wms_base.constants import DATE_TIME_INFINITY
 
 register = Declarations.register
 Model = Declarations.Model

--- a/anyblok_wms_base/dbapi.py
+++ b/anyblok_wms_base/dbapi.py
@@ -15,7 +15,9 @@ In particular, supporting a new DBAPI adapter such as pygresql should
 involve modifying this module only.
 """
 import psycopg2
-from psycopg2.extras import DateTimeTZRange  # noqa (reexport)
+from psycopg2.extras import DateTimeTZRange as TimeSpan
+
+EMPTY_TIMESPAN = TimeSpan(empty=True)
 
 
 class DbConstant:
@@ -45,14 +47,12 @@ def cast_tstz(value, cr):
         return DATE_TIME_INFINITY
     return psycopg2.extensions.PYDATETIMETZ(value, cr)
 
-from psycopg2.extensions import string_types
 
 TSTZ_WITH_INFINITY = psycopg2.extensions.new_type(
     psycopg2.extensions.PYDATETIMETZ.values,
     'TSTZ_WITH_INFINITY',
     cast_tstz)
 psycopg2.extensions.register_type(TSTZ_WITH_INFINITY)
-
 
 
 class DbConstantAdapter:

--- a/anyblok_wms_base/dbapi.py
+++ b/anyblok_wms_base/dbapi.py
@@ -14,6 +14,9 @@ DBAPI adapter in use.
 In particular, supporting a new DBAPI adapter such as pygresql should
 involve modifying this module only.
 """
+from datetime import (
+    timezone,
+)
 import psycopg2
 from psycopg2.extras import DateTimeTZRange as TimeSpan
 
@@ -40,6 +43,8 @@ For instance, if a method is used to query Avatars for a given date, using
 this marker in the interface is more explicit than using None (which could
 also mean one does not care about dates).
 """
+
+DATE_TIME_INFINITY.tzinfo = timezone.utc
 
 
 def cast_tstz(value, cr):

--- a/anyblok_wms_base/dbapi.py
+++ b/anyblok_wms_base/dbapi.py
@@ -79,7 +79,7 @@ ts_orig_contains = TimeSpan.__contains__
 
 
 def ts_contains(ts, dt):
-    """Monkey-patch of the 'in' operator of TimeSpan to deal with infinity.
+    """Patching of the 'in' operator of :class:`TimeSpan` to deal with infinity.
 
     Necessary because the partial comparison support doesn't work with
     infinity in the right hand side.
@@ -119,17 +119,19 @@ def ts_contains(ts, dt):
     >>> DATE_TIME_INFINITY in shorter_excl
     True
 
-    Corner cases with empty timespan at infiniy
-    >>> any(dti in TimeSpan(lower=inf, upper=inf, bounds=bounds)
-    ...     for dti in (inf, dt) for bounds in ('[)', '()'))
-    False
+    Corner cases with empty timespans at infinity::
+
+      >>> any(dti in TimeSpan(lower=inf, upper=inf, bounds=bounds)
+      ...     for dti in (inf, dt) for bounds in ('[)', '()'))
+      False
 
     Here's the finite case::
-    >>> normal = TimeSpan(lower=dt, upper=later, bounds='[)')
-    >>> dt in normal
-    True
-    >>> later in normal
-    False
+
+      >>> normal = TimeSpan(lower=dt, upper=later, bounds='[)')
+      >>> dt in normal
+      True
+      >>> later in normal
+      False
     """
     if dt is DATE_TIME_INFINITY:
         return ts.upper is DATE_TIME_INFINITY and ts.upper_inc

--- a/anyblok_wms_base/dbapi.py
+++ b/anyblok_wms_base/dbapi.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# This file is a part of the AnyBlok / WMS Base project
+#
+#    Copyright (C) 2018 Georges Racinet <gracinet@anybox.fr>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file,You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+"""DBAPI Adapters customization.
+
+This module encapsulates all assumptions and alterations of the low level
+DBAPI adapter in use.
+
+In particular, supporting a new DBAPI adapter such as pygresql should
+involve modifying this module only.
+"""
+import psycopg2
+from psycopg2.extras import DateTimeTZRange  # noqa (reexport)
+
+
+class DbConstant:
+
+    def __init__(self, dbrepr, as_str=None):
+        self.dbrepr = dbrepr
+        self.as_str = dbrepr.decode() if as_str is None else as_str
+
+    def __repr__(self):
+        return 'DbConstant(%r)' % self.dbrepr
+
+    def __str__(self):
+        return self.as_str
+
+
+DATE_TIME_INFINITY = DbConstant(b"'infinity'::timestamptz")
+"""A marker used to represent +infinity date/time.
+
+For instance, if a method is used to query Avatars for a given date, using
+this marker in the interface is more explicit than using None (which could
+also mean one does not care about dates).
+"""
+
+
+def cast_tstz(value, cr):
+    if value == "infinity":
+        return DATE_TIME_INFINITY
+    return psycopg2.extensions.PYDATETIMETZ(value, cr)
+
+from psycopg2.extensions import string_types
+
+TSTZ_WITH_INFINITY = psycopg2.extensions.new_type(
+    psycopg2.extensions.PYDATETIMETZ.values,
+    'TSTZ_WITH_INFINITY',
+    cast_tstz)
+psycopg2.extensions.register_type(TSTZ_WITH_INFINITY)
+
+
+
+class DbConstantAdapter:
+    """Proper conversion of DATE_TIME_INFINITY.
+
+    .. seealso::
+
+        The official Psycopg `instructions
+        <http://initd.org/psycopg/docs/usage.html#infinite-dates-handling>`
+    """
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+    def getquoted(self):
+        return self.wrapped.dbrepr
+
+
+psycopg2.extensions.register_adapter(DbConstant, DbConstantAdapter)

--- a/anyblok_wms_base/dbapi.py
+++ b/anyblok_wms_base/dbapi.py
@@ -24,6 +24,27 @@ EMPTY_TIMESPAN = TimeSpan(empty=True)
 
 
 class DbConstant:
+    """Represents a Database constant
+
+    The instantiation is done with the quoted database representation,
+    as :class:`bytes`.
+
+      >>> nan = DbConstant(b"'nan'::numeric")
+      >>> str(nan)
+      "'nan'::numeric"
+      >>> print(repr(nan))
+      DbConstant(b"'nan'::numeric")
+
+    One can also provide the value of str for cosmetic reasons.
+    In the unlikely case that the quoted DB representation couldn't be decoded
+    to :class:`str`, this would also be useful.
+
+      >>> nan = DbConstant(b"'nan'::numeric", as_str='NaN')
+      >>> str(nan)
+      'NaN'
+      >>> print(repr(nan))
+      DbConstant(b"'nan'::numeric")
+    """
 
     def __init__(self, dbrepr, as_str=None):
         self.dbrepr = dbrepr
@@ -97,6 +118,18 @@ def ts_contains(ts, dt):
     False
     >>> DATE_TIME_INFINITY in shorter_excl
     True
+
+    Corner cases with empty timespan at infiniy
+    >>> any(dti in TimeSpan(lower=inf, upper=inf, bounds=bounds)
+    ...     for dti in (inf, dt) for bounds in ('[)', '()'))
+    False
+
+    Here's the finite case::
+    >>> normal = TimeSpan(lower=dt, upper=later, bounds='[)')
+    >>> dt in normal
+    True
+    >>> later in normal
+    False
     """
     if dt is DATE_TIME_INFINITY:
         return ts.upper is DATE_TIME_INFINITY and ts.upper_inc

--- a/anyblok_wms_base/quantity/operation/aggregate.py
+++ b/anyblok_wms_base/quantity/operation/aggregate.py
@@ -10,7 +10,6 @@
 from anyblok import Declarations
 from anyblok.column import Integer
 
-from anyblok_wms_base.utils import min_upper_bounds
 from anyblok_wms_base.exceptions import (
     OperationInputsError,
 )
@@ -126,8 +125,6 @@ class Aggregate(Mixin.WmsSingleOutcomeOperation,
         dt_exec = self.dt_execution
         PhysObj = self.registry.Wms.PhysObj
 
-        outcome_dt_until = min_upper_bounds(g.dt_until for g in inputs)
-
         if self.state == 'done':
             update = dict(dt_until=dt_exec, state='past')
         else:
@@ -148,7 +145,6 @@ class Aggregate(Mixin.WmsSingleOutcomeOperation,
             outcome_of=self,
             dt_from=dt_exec,
             # dt_until in states 'present' and 'future' is theoretical anyway
-            dt_until=outcome_dt_until,
             state='present' if self.state == 'done' else 'future',
             location=self.unique_inputs_location(inputs))
 

--- a/anyblok_wms_base/quantity/operation/aggregate.py
+++ b/anyblok_wms_base/quantity/operation/aggregate.py
@@ -126,11 +126,8 @@ class Aggregate(Mixin.WmsSingleOutcomeOperation,
         PhysObj = self.registry.Wms.PhysObj
 
         if self.state == 'done':
-            update = dict(dt_until=dt_exec, state='past')
-        else:
-            update = dict(dt_until=dt_exec)
-        for record in inputs:
-            record.update(**update)
+            for record in inputs:
+                record.state = 'past'
 
         tpl_avatar = next(iter(inputs))
         tpl_physobj = tpl_avatar.obj

--- a/anyblok_wms_base/quantity/operation/split.py
+++ b/anyblok_wms_base/quantity/operation/split.py
@@ -100,7 +100,6 @@ class Split(SingleInput, InPlace, Operation):
             dt_from=self.dt_execution,
             dt_until=None,
         )
-        avatar.dt_until = self.dt_execution
         if avatar.state == 'present':
             # splitting must occur immediately, otherwise we may
             # have no present avatar with non empty timespan
@@ -157,9 +156,8 @@ class Split(SingleInput, InPlace, Operation):
 
     def execute_planned(self):
         for outcome in self.outcomes:
-            outcome.update(state='present', dt_from=self.dt_execution)
-        self.registry.flush()
-        self.input.update(state='past', dt_until=self.dt_execution)
+            outcome.state = 'present'
+        self.input.state = 'past'
         self.registry.flush()
 
     def is_reversible(self):

--- a/anyblok_wms_base/quantity/operation/split.py
+++ b/anyblok_wms_base/quantity/operation/split.py
@@ -98,7 +98,7 @@ class Split(SingleInput, InPlace, Operation):
             location=avatar.location,
             outcome_of=self,
             dt_from=self.dt_execution,
-            dt_until=avatar.dt_until,
+            dt_until=None,
         )
         avatar.dt_until = self.dt_execution
         if self.state == 'done':

--- a/anyblok_wms_base/quantity/operation/split.py
+++ b/anyblok_wms_base/quantity/operation/split.py
@@ -101,6 +101,13 @@ class Split(SingleInput, InPlace, Operation):
             dt_until=None,
         )
         avatar.dt_until = self.dt_execution
+        if avatar.state == 'present':
+            # splitting must occur immediately, otherwise we may
+            # have no present avatar with non empty timespan
+            # TODO and if we are following an Operation,
+            # actually the split must execute at once once that latter
+            # executes, for the same reason
+            self.state = 'done'
         if self.state == 'done':
             avatar.update(state='past')
             new_avatars['state'] = 'present'

--- a/anyblok_wms_base/quantity/operation/tests/test_aggregate.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_aggregate.py
@@ -223,7 +223,6 @@ class TestAggregate(WmsTestCase):
         for avatar in self.avatars:
             avatar.state = 'present'
             avatar.obj.properties = props
-
         agg = self.plan_aggregate()
         self.assertEqual(agg.inputs, self.avatars)
         self.assert_quantity(3)

--- a/anyblok_wms_base/quantity/operation/tests/test_departure.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_departure.py
@@ -6,7 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
-from anyblok_wms_base.dbapi import DateTimeTZRange as DTRange
+from anyblok_wms_base.dbapi import TimeSpan
 from anyblok_wms_base.testing import WmsTestCaseWithPhysObj
 
 
@@ -76,8 +76,9 @@ class TestDeparture(WmsTestCaseWithPhysObj):
 
         sent = dep.input
         self.assertEqual(sent.state, 'past')
-        self.assertEqual(sent.timespan, DTRange(lower=self.dt_test1,
-                                                upper=self.dt_test3))
+        self.assertEqual(sent.timespan, TimeSpan(lower=self.dt_test1,
+                                                 upper=self.dt_test3,
+                                                 bounds='[)'))
         self.assertEqual(sent.obj.quantity, 1)
         # dt_until being exclusive,
         # at self.dt_test3 the physical objects were already sent,

--- a/anyblok_wms_base/quantity/operation/tests/test_departure.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_departure.py
@@ -6,6 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
+from anyblok_wms_base.dbapi import DateTimeTZRange as DTRange
 from anyblok_wms_base.testing import WmsTestCaseWithPhysObj
 
 
@@ -57,6 +58,7 @@ class TestDeparture(WmsTestCaseWithPhysObj):
                                past=(3, self.dt_test1))
 
     def test_partial_planned_execute(self):
+        self.avatar.state = 'present'
         dep = self.Departure.create(quantity=1,
                                     state='planned',
                                     dt_execution=self.dt_test2,
@@ -66,7 +68,6 @@ class TestDeparture(WmsTestCaseWithPhysObj):
         self.assertEqual(split.type, 'wms_split')
         self.assert_singleton(split.follows, value=self.arrival)
 
-        self.avatar.state = 'present'
         self.assert_quantities(future=(2, self.dt_test2),
                                present=3,
                                past=(3, self.dt_test1))
@@ -75,7 +76,8 @@ class TestDeparture(WmsTestCaseWithPhysObj):
 
         sent = dep.input
         self.assertEqual(sent.state, 'past')
-        self.assertEqual(sent.dt_until, self.dt_test3)
+        self.assertEqual(sent.timespan, DTRange(lower=self.dt_test1,
+                                                upper=self.dt_test3))
         self.assertEqual(sent.obj.quantity, 1)
         # dt_until being exclusive,
         # at self.dt_test3 the physical objects were already sent,

--- a/anyblok_wms_base/quantity/operation/tests/test_move.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_move.py
@@ -6,6 +6,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file,You can
 # obtain one at http://mozilla.org/MPL/2.0/.
+from anyblok_wms_base.constants import EMPTY_TIMESPAN
 from anyblok_wms_base.testing import WmsTestCaseWithPhysObj
 
 
@@ -30,8 +31,9 @@ class TestMove(WmsTestCaseWithPhysObj):
         # the original has been thrown in the past by the split
         self.assertEqual(self.avatar.obj.quantity, 3)
         self.assertEqual(self.avatar.state, 'past')
-        self.assertEqual(self.avatar.dt_from, self.dt_test1)
-        self.assertEqual(self.avatar.dt_until, self.dt_test2)
+        # consistently with comment in Splitter mixin,
+        # the one with empty timespan is the one that has been split
+        self.assertEqual(self.avatar.timespan, EMPTY_TIMESPAN)
 
         not_moved = self.assert_singleton(split.leaf_outcomes())
         self.assertEqual(not_moved.obj.quantity, 2)
@@ -58,8 +60,9 @@ class TestMove(WmsTestCaseWithPhysObj):
         # the original has been thrown in the past by the split
         self.assertEqual(self.avatar.obj.quantity, 3)
         self.assertEqual(self.avatar.state, 'past')
-        self.assertEqual(self.avatar.dt_from, self.dt_test1)
-        self.assertEqual(self.avatar.dt_until, self.dt_test2)
+        # consistently with comment in Splitter mixin,
+        # the one with empty timespan is the one that has been split
+        self.assertEqual(self.avatar.timespan, EMPTY_TIMESPAN)
 
         not_moved = self.assert_singleton(split.leaf_outcomes())
         self.assertEqual(not_moved.obj.quantity, 2)

--- a/anyblok_wms_base/quantity/operation/tests/test_move.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_move.py
@@ -15,7 +15,6 @@ class TestMove(WmsTestCaseWithPhysObj):
 
     def setUp(self):
         super(TestMove, self).setUp()
-        self.avatar.dt_until = self.dt_test3
         self.Move = self.Operation.Move
 
     def test_partial_done(self):
@@ -40,7 +39,7 @@ class TestMove(WmsTestCaseWithPhysObj):
         after_move = self.assert_singleton(move.outcomes)
         self.assertEqual(after_move.obj.quantity, 1)
         self.assertEqual(after_move.dt_from, self.dt_test2)
-        self.assertEqual(after_move.dt_until, self.dt_test3)
+        self.assertIsNone(after_move.dt_until)
         self.assertEqual(after_move.location, self.stock)
 
     def test_partial_planned_execute(self):
@@ -69,7 +68,7 @@ class TestMove(WmsTestCaseWithPhysObj):
         self.assertEqual(after_move.obj.quantity, 1)
         self.assertEqual(after_move.location, self.stock)
         self.assertEqual(after_move.dt_from, self.dt_test2)
-        self.assertEqual(after_move.dt_until, self.dt_test3)
+        self.assertIsNone(after_move.dt_until)
         self.assertEqual(after_move.state, 'present')
 
 

--- a/anyblok_wms_base/quantity/operation/tests/test_split.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_split.py
@@ -62,7 +62,6 @@ class TestSplit(WmsTestCaseWithPhysObj):
 
         self.assertEqual(len(all_outcomes), 2)
 
-        self.assertEqual(self.avatar.state, 'present')
         self.assertEqual(self.avatar.dt_from, self.dt_test1)
         self.assertEqual(self.avatar.dt_until, self.dt_test2)
         self.assertEqual(sum(out.obj.quantity for out in all_outcomes), 3)
@@ -77,7 +76,9 @@ class TestSplit(WmsTestCaseWithPhysObj):
         for outcome in all_outcomes:
             self.assertEqual(outcome.dt_from, self.dt_test2)
             self.assertEqual(outcome.location, self.incoming_loc)
-            self.assertEqual(outcome.state, 'future')
+            # since introduction of TimeSpans, split auto execute
+            # on 'present' inputs
+            self.assertEqual(outcome.state, 'present')
             self.assertEqual(outcome.obj.type, self.physobj_type)
         wished_outcome = split.wished_outcome
         self.assertEqual(wished_outcome.obj.quantity, 2)

--- a/anyblok_wms_base/quantity/operation/tests/test_unpack.py
+++ b/anyblok_wms_base/quantity/operation/tests/test_unpack.py
@@ -290,6 +290,8 @@ class TestUnpack(WmsTestCase):
         # after actual instantiation, but we can't test it because
         # we don't have a create() returned value to compare
 
+        self.packs.dt_until = None  # cleanup for retry
+
         # Having properties, still missing the required one
         self.packs.obj.properties = self.PhysObj.Properties.insert(
             flexible=dict(bar=1))

--- a/anyblok_wms_base/testing.py
+++ b/anyblok_wms_base/testing.py
@@ -215,9 +215,9 @@ class WmsTestCaseWithPhysObj(SharedDataTestCase, WmsTestCase):
                                                state='planned',
                                                dt_execution=cls.dt_test1,
                                                **cls.arrival_kwargs)
-
         assert len(cls.arrival.outcomes) == 1
         cls.avatar = cls.arrival.outcome
+        assert cls.avatar.dt_until is None
         cls.physobj = cls.avatar.obj
         cls.Avatar = cls.PhysObj.Avatar
 

--- a/doc/apidoc/core/operation/abstract.rst
+++ b/doc/apidoc/core/operation/abstract.rst
@@ -37,6 +37,7 @@ Model.Wms.Operation
    .. automethod:: plan_revert
    .. automethod:: obliviate
    .. automethod:: alter_destination
+   .. automethod:: alter_dt_execution
 
    .. raw:: html
 
@@ -81,7 +82,6 @@ Model.Wms.Operation.HistoryInput
 
    .. autoattribute:: operation
    .. autoattribute:: avatar
-   .. autoattribute:: orig_dt_until
 
 
 Helper Mixin classes

--- a/doc/apidoc/core/physobj.rst
+++ b/doc/apidoc/core/physobj.rst
@@ -107,6 +107,8 @@ Model.Wms.PhysObj.Avatar
    .. autoattribute:: outcome_of
    .. autoattribute:: location
    .. autoattribute:: state
+   .. autoattribute:: timespan
    .. autoattribute:: dt_from
    .. autoattribute:: dt_until
    .. autoattribute:: id
+   .. automethod:: define_table_args

--- a/doc/apidoc/index.rst
+++ b/doc/apidoc/index.rst
@@ -11,6 +11,7 @@ package names for readability in page titles.
    :maxdepth: 2
 
    constants
+   dbapi
    exceptions
    utils
    core/index

--- a/doc/for_downstream.rst
+++ b/doc/for_downstream.rst
@@ -27,6 +27,16 @@ to be customized by the local DBA.
              from the strongest integrity constraints, nor the fastest
              indexing solutions.
 
+.. note:: if one tries to restore a database dump into a database that
+          doesn't have the extension, without superuser database
+          privilege, this ends up in error at the
+          creation of the constraint(s) that needs it, producing an empty
+          database. Its common for remount script to
+          accept non zero return codes from ``pg_restore`` because of
+          ``CREATE COMMENT`` on extensions. These should check
+          explicitely stderr about ``btree_gist`` creation errors.
+          Here again, using a database template makes things simpler.
+
 .. _arch:
 
 Architecture

--- a/doc/for_downstream.rst
+++ b/doc/for_downstream.rst
@@ -1,6 +1,32 @@
 For downstream developers and deployers
 =======================================
 
+.. _install:
+
+Installation
+~~~~~~~~~~~~
+
+Database
+--------
+
+.. warning:: AnyBlok WMS / Base supports PostgreSQL only.
+
+It is strongly recommended to install the `btree_gist
+<https://www.postgresql.org/docs/11/btree-gist.html>`_ PostgreSQL
+extension::
+
+  CREATE EXTENSION btree_gist;
+
+This requires PostgreSQL administration privileges. If you want it to
+be automatically available in databases created automatically by
+unprivileged ``anyblok_createdb`` processes, you can install it in appropriate
+database template, for instance ``template1``, the default one meant
+to be customized by the local DBA.
+
+.. warning:: If ``btree_gist`` is not available, your database will not benefit
+             from the strongest integrity constraints, nor the fastest
+             indexing solutions.
+
 .. _arch:
 
 Architecture

--- a/doc/improvements.rst
+++ b/doc/improvements.rst
@@ -117,7 +117,43 @@ planification, and maybe implementations of
 :ref:`improvement_operation_superseding` in a way that'd be akin to the
 obsolescence markers of Mercurial, but that's probably too far fetched.
 
-Decision about all this postponed until version 0.9
+Implementation based on date/time ranges
+++++++++++++++++++++++++++++++++++++++++
+
+.. note:: August 2019 addendum, part of migration to date/time ranges
+
+.Here's a plan that should work, using the replacement of
+``dt_from`` and ``dt_until`` by a range
+(:py:attr:`timespan <anyblok_wms_base.core.physobj.main.Avatar.timespan>`) and
+the :py:data:`infinity <anyblok_wms_base.dbapi.DATE_TIME_INFINITY>` value:
+
+- timespan ``None``: undetermined non terminal Avatar
+- timespan ``[infinity, infinity]``: undetermined
+  terminal Avatar (still appears in future quantity queries
+  at infinity). The ``[infinity, None)`` value would probably also
+  work and provide easier compatibility (the test for terminality
+  would be that the the timespan upper bound is ``None``, same as it
+  is now for semi-determinate Avatars).
+- all these indetermined Avatars would be produced by Operations whose
+  ``dt_execution`` is "indeterminate", i.e., ``None`` or maybe infinity,
+  provied that infinity becomes the default value in ``create()``.
+  In particular, we'd stop initializing ``dt_execution``
+  from the inputs' ``dt_from`` by default.
+- upon execution of an Operation with previously indeterminate
+  ``dt_execution``, we'd simply make its outcomes
+  semi-determinate: ``[dt_execution, None)``
+  (maybe ``[dt_execution, infinity]``, depending on the choice made
+  for terminal indeterminate Avatar above). Nothing would have to be
+  propagated, since all
+  descendent Avatars of an indeterminate one would be indeterminate.
+- data migration: nothing to be done, assuming migration to timespans
+  would have already been done. The upcoming
+  timespan support already deals with all corner cases
+  (notably related to empty timespans). Existing
+  Operations jsut wouldn't get the performance boost and the robustness of
+  the new, simpler scheme. Some cleanups could be decided and
+  implemented later, when most ``future`` Avatars of production
+  database created before this change would be at least ``present``.
 
 .. _improvement_federation:
 

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -83,7 +83,9 @@ def run(db_name, nose_additional_opts):
                       ANYBLOK_DATABASE_DRIVER=driver)
 
     awb_dir = os.path.join(os.path.dirname(sys.argv[0]), 'anyblok_wms_base')
-    doctests([os.path.join(awb_dir, 'utils.py')],
+    doctests([os.path.join(awb_dir, 'utils.py'),
+              os.path.join(awb_dir, 'dbapi.py'),
+              ],
              nose_additional_opts, cover_erase=True)
     bloks_dir = awb_dir
     dropdb(db_name)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ anyblok_init = [
 
 requirements = [
     'anyblok>=0.22.0',
-    'anyblok_postgres',
+    'anyblok_postgres>=0.2.0',
 ]
 
 # it is a bit lame, because ideally we'd prefer to


### PR DESCRIPTION
A branch that replaces the `dt_from` and `dt_until` attributes with a database range.

It comes with the enforcement that Avatars don't overlab by an opional database constraint (depending on the `btree_gist` extension) and plan to implement sane indetermintate times in Avatars and Operations (see `doc/improvements.rst`).

Remaining work to be done :

- [ ] more tests. especially more unitary. Too much testing is done by hard to debug tests for higher level mechanisms (like chain revert execute).
- [ ] checking what happens upon restoring a dump taken from a DB that has the `btree_gist` extension and similar scenarios
- [ ] data migration
- [ ] reorganisation in a few reasonably self-contained commits. If I can understand them later, it's good enough, but having the tests passing in all of them is probably just impossible unless we squash everything or we make heavy use of skip decorators in intermeditate commits.
 