### PR TITLE
WIP: evaluate anyblok compatibility version

### DIFF
--- a/anyblok_wms_base/core/operation/tests/test_assembly.py
+++ b/anyblok_wms_base/core/operation/tests/test_assembly.py
@@ -1405,7 +1405,7 @@ class TestTypedExpression(BlokTestCase):
 
     def test_seq(self):
         self.registry.System.Sequence.insert(code='prd',
-                                             number=12,
+                                             start=12,
                                              formater='PRD/{seq}')
         self.assertEqual(self.eval_typed_expr('sequence', 'prd'), 'PRD/12')
         self.assertEqual(self.eval_typed_expr('sequence', 'prd'), 'PRD/13')

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ anyblok_init = [
 ]
 
 requirements = [
-    'anyblok<1.1.0',
+    'anyblok<1.2.0',
     'sqlalchemy==1.3.23',
     'anyblok_postgres',
     'alembic==1.5.2',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
     'anyblok<1.2.0',
     'sqlalchemy<1.3.23',
     'anyblok_postgres',
-    'alembic<1.5.2',
+    'alembic',
 ]
 
 # it is a bit lame, because ideally we'd prefer to

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ anyblok_init = [
 
 requirements = [
     'anyblok<1.2.0',
-    'sqlalchemy==1.3.23',
+    'sqlalchemy<1.3.23',
     'anyblok_postgres',
-    'alembic==1.5.2',
+    'alembic<1.5.2',
 ]
 
 # it is a bit lame, because ideally we'd prefer to

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,11 @@ anyblok_init = [
 ]
 
 requirements = [
-    'anyblok>=0.22.0',
+    'anyblok>=0.22.5',
     'anyblok_postgres',
+    'psycopg2-binary==2.8.3',
+    'sqlalchemy==1.3.6',
+    'alembic==1.0.11',
 ]
 
 # it is a bit lame, because ideally we'd prefer to

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ anyblok_init = [
 ]
 
 requirements = [
-    'anyblok<1.0.0',
+    'anyblok<1.1.0',
     'sqlalchemy==1.3.23',
     'anyblok_postgres',
     'alembic==1.5.2',

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,10 @@ anyblok_init = [
 ]
 
 requirements = [
-    'anyblok>=0.22.5',
+    'anyblok<1.0.0',
+    'sqlalchemy==1.3.23',
     'anyblok_postgres',
-    'psycopg2-binary==2.8.3',
-    'sqlalchemy==1.3.6',
-    'alembic==1.0.11',
+    'alembic==1.5.2',
 ]
 
 # it is a bit lame, because ideally we'd prefer to


### PR DESCRIPTION
This branch is starting point to make AWB compatible with the latest anyblok version. and ensure which dependency version are compatible and evaluate the migration effort

- [x] first commit: freezing version likes in master 
- [x] commit 2: test the most recent lib that we can work with without any changes
- [x] adapt unittest code using anyblok v1.0.0, sequence initialization change field name (`number` -> `start`)  https://github.com/AnyBlok/AnyBlok/issues/45
- [x] test anyblok version < 1.2.0
- [ ] replace nosetest by pytest and move unittest to fixture style
- [ ] adapt to anyblok>= 1.2.0 and sqla >1.4.0 following deprecation warning (discuss with the community to decide which PR should merged before starting that poin)
---
## TODO:

- [ ] investigate why sqlalchemy version 1.3.24 is failing 
- [ ] investigate why alembic version 1.5.3 is failing